### PR TITLE
fix #326 magic value for thumbnail video height

### DIFF
--- a/materialious/src/lib/Thumbnail.svelte
+++ b/materialious/src/lib/Thumbnail.svelte
@@ -28,6 +28,7 @@
 	let videoPreview: VideoPlay | null = null;
 	let videoPreviewMuted: boolean = true;
 	let videoPreviewVolume: number = 0.4;
+	let imgHeight: number;
 
 	let proxyVideos = get(playerProxyVideosStore);
 
@@ -210,6 +211,7 @@
 		on:mouseover={previewVideo}
 		on:mouseleave={() => (showVideoPreview = false)}
 		on:focus={() => {}}
+		bind:clientHeight={imgHeight}
 		role="region"
 	>
 		<a
@@ -222,9 +224,9 @@
 				<progress class="circle"></progress>
 			{:else if loaded}
 				{#if showVideoPreview && videoPreview}
-					<div style="max-width: 100%; max-height: 200px;">
+					<div style="max-width: 100%; max-height: {imgHeight}px;">
 						<video
-							style="max-width: 100%; max-height: 200px;"
+							style="max-width: 100%; height: {imgHeight}px;"
 							autoplay
 							poster={img.src}
 							width="100%"


### PR DESCRIPTION
Previously the height of the thumbnail videos was fixed at 200px, now we use the previous height of the div to set the height for the preview video appropriately.