### PR TITLE
removed version line in compose file, this is now obsolete

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+---
 services:
   materialious:
     image: wardpearce/materialious

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -120,7 +120,7 @@ Please ensure you have followed the previous steps before doing this!
 ### Docker Compose
 
 ```yaml
-version: "3"
+---
 services:
   materialious:
     image: wardpearce/materialious:latest


### PR DESCRIPTION
Removed "version: "3"" from docker compose. Specifying version is now obsolete and will throw a warning from Docker stating "'version' is obsolete'"