### PR TITLE
Fix minor typo in DOCKER.md

### DIFF
--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -309,7 +309,7 @@ services:
       - 3004:80
     environment:
       api_extended_postgre: '{"host": "invidious-db", "port": 5432, "database": "invidious", "user": "kemal", "password": "kemal"}'
-      api_extended_allowed_origins: '["https://materialios.example.com"]'
+      api_extended_allowed_origins: '["https://materialious.example.com"]'
       api_extended_debug: false
 
       # No trailing backslashes!


### PR DESCRIPTION
In the part about self-hosting the extended api/syncious I stumbled over a small typo.

I had copy-pasted the config and just changed the domain part (example.com to my own domain). But because my Materialious subdomain was (correctly) written with "ou" and the example had it with "o" only I kept getting CORS errors and did not understand why, until I finally spotted the typo.

I hope this PR helps others to not stumble over this 😄 