### PR TITLE
Update translations > German; added Dutch and Serbo-Croatian

### DIFF
--- a/materialious/src/lib/i18n/index.ts
+++ b/materialious/src/lib/i18n/index.ts
@@ -7,6 +7,7 @@ register('en', () => import('./locales/en.json'));
 register('ru', () => import('./locales/ru.json'));
 register('zh-CN', () => import('./locales/zh-CN.json'));
 register('tr', () => import('./locales/tr.json'));
+register('nl', () => import('./locales/nl.json'));
 register('de', () => import('./locales/de.json'));
 
 init({

--- a/materialious/src/lib/i18n/index.ts
+++ b/materialious/src/lib/i18n/index.ts
@@ -9,6 +9,7 @@ register('zh-CN', () => import('./locales/zh-CN.json'));
 register('tr', () => import('./locales/tr.json'));
 register('nl', () => import('./locales/nl.json'));
 register('de', () => import('./locales/de.json'));
+register('sh', () => import('./locales/sh.json'));
 
 init({
 	fallbackLocale: defaultLocale,

--- a/materialious/src/lib/i18n/locales/de.json
+++ b/materialious/src/lib/i18n/locales/de.json
@@ -25,8 +25,8 @@
 	"hideReplies": "Antworten verstecken",
 	"hideVideo": "Video verstecken",
 	"syncParty": {
-		"userJoined": "Ein Benutzer ist Ihrer Watch-Party beigetreten.",
-		"userLeft": "Ein Benutzer hat ihre Watch-Party verlassen.",
+		"userJoined": "Ein Benutzer ist Ihrer Anzeiggruppe beigetreten.",
+		"userLeft": "Ein Benutzer hat ihre Anzeiggruppe verlassen.",
 		"userOnPrivatePage": "Der Benutzer sieht gerade eine private Seite, die Synchronisierung wird in Kürze fortgesetzt."
 	},
 	"videoTabs": {
@@ -92,7 +92,7 @@
 	},
 	"layout": {
 		"interface": "Schnittstelle",
-		"star": "Sternchen auf GitHub vergeben",
+		"star": "Sternchen auf GitHub vergeben!",
 		"syncParty": "Synchronisierung der Partei",
 		"syncPartyWarning": "Bitte beachten Sie, dass Ihre IP für die von Ihnen eingeladenen Benutzer sichtbar ist.",
 		"startSyncParty": "Synchronisierung der Partei starten",
@@ -130,7 +130,7 @@
 			"miniPlayer": "Minispieler",
 			"proxyVideos": "Proxy-Videos",
 			"backgroundPlay": "Ton im Hintergrund abspielen",
-			"dash": "Bindestrich",
+			"dash": "Bindestrichmodus",
 			"silenceSkipper": "Schweigenüberspringer (Experimentell)",
 			"youtubeJsFallback": "Fallback für lokale Videoverarbeitung",
 			"youtubeJsAlways": "Verwenden Sie immer die lokale Videoverarbeitung",
@@ -143,11 +143,11 @@
 			"disableToast": "Toast deaktivieren",
 			"disableTimeline": "Segmente auf der Zeitleiste deaktivieren",
 			"Catagories": "Kategorien",
-			"unpaidSelfPromotion": "Unbezahlte / Selbstständige Förderung",
+			"unpaidSelfPromotion": "Unbezahlte/Selbstständige Förderung",
 			"interactionReminder": "Interaktionserinnerung (Abonnieren)",
 			"intermissionIntroAnimation": "Unterbrechung/Einstiegsanimation",
 			"credits": "Endkarten/Gutschriften",
-			"preViewRecapHook": "Vorschau/Rückblick/Hook",
+			"preViewRecapHook": "Vorschau/Rückblick/Haken",
 			"tangentJokes": "Füller Tangent/Witze"
 		},
 		"deArrow": {

--- a/materialious/src/lib/i18n/locales/de.json
+++ b/materialious/src/lib/i18n/locales/de.json
@@ -1,133 +1,160 @@
 {
-    "enabled": "Aktiviert",
-    "copyUrl": "URL kopieren",
-    "loadMore": "Mehr laden",
-    "views": "Ansichten",
-    "videos": "Videos",
-    "cancel": "Abbrechen",
-    "create": "Erstellen",
-    "title": "Titel",
-    "searchPlaceholder": "Suchen...",
-    "delete": "Löschen",
-    "deleteAllHistory": "Gesamten Verlauf löschen",
-    "skipping": "Überspringen",
-    "replies": "antworten",
-    "region": "Region",
-    "noResult": "Keine Ergebnisse",
-    "language": "Sprache",
-    "transcript": "Transkript",
-    "noCaptionData": "Untertitel enthalten keine daten.",
-    "selectLang": "Sprache auswählen",
-    "letterCase": "Groß-/Kleinschreibung für Titel",
-    "hideReplies": "Antworten verstecken",
-    "hideVideo": "Video verstecken",
-    "syncParty": {
-        "userJoined": "Ein Benutzer ist Ihrer Watch-Party beigetreten.",
-        "userLeft": "Ein Benutzer hat ihre Watch-Party verlassen.",
-        "userOnPrivatePage": "Der Benutzer sieht gerade eine private Seite, die Synchronisierung wird in Kürze fortgesetzt."
-    },
-    "videoTabs": {
-        "all": "Alle",
-        "videos": "Videos",
-        "playlists": "Wiedergabeliste",
-        "channels": "Kanäle",
-        "shorts": "Shorts",
-        "streams": "Streams"
-    },
-    "subscriptions": {
-        "manageSubscriptions": "Abonnements verwalten"
-    },
-    "playlist": {
-        "createPlaylist": "Wiedergabeliste erstellen",
-        "public": "Öffentlich",
-        "unlisted": "Ungelistet",
-        "private": "Privat",
-        "playVideos": "Videos abspielen",
-        "shuffleVideos": "Videos in zufälliger Reihenfolge abspielen",
-        "loopPlaylist": "Wiedergabeliste in Schleife abspielen"
-    },
-    "thumbnail": {
-        "live": "LIVE",
-        "failedToLoadImage": "Laden des Bildes fehlgeschlagen"
-    },
-    "pages": {
-        "home": "Startseite",
-        "trending": "Beliebt",
-        "subscriptions": "Abonnements",
-        "history": "Verlauf",
-        "playlists": "Wiedergabelisten"
-    },
-    "subscribers": "Abonnenten",
-    "unsubscribe": "Deabonnieren",
-    "loginRequired": "Anmeldung erforderlich",
-    "player": {
-        "audioOnly": "Nur Ton",
-        "theatreMode": "Theatermodus",
-        "share": {
-            "title": "Teilen",
-            "materialiousLink": "Materialious link kopieren",
-            "invidiousRedirect": "Invidious Weiterleitungslink kopieren",
-            "youtubeLink": "YouTube Link kopieren"
-        },
-        "download": "Herunterladen",
-        "noPlaylists": "Keine Wiedergabelisten",
-        "unableToLoadComments": "Laden der Kommentare fehlgeschlagen",
-        "addToPlaylist": "Zur Wiedergabeliste hinzufügen"
-    },
-    "layout": {
-        "star": "Sternchen auf GitHub vergeben",
-        "syncPartyWarning": "Bitte beachten Sie, dass Ihre IP für die von Ihnen eingeladenen Benutzer sichtbar ist.",
-        "startSyncParty": "Sync-Party starten",
-        "endSyncParty": "Sync-Party beenden",
-        "notifications": "Benachrichtigungen",
-        "noNewNotifications": "Keine neuen Benachrichtigungen",
-        "settings": "Einstellungen",
-        "login": "Anmelden",
-        "logout": "Abmelden",
-        "customize": "Anpassen",
-        "theme": {
-            "theme": "Thema",
-            "darkMode": "Dunkler Modus",
-            "lightMode": "Heller Modus",
-            "color": "Farbe"
-        },
-        "searchSuggestions": "Suchvorschläge",
-        "previewVideoOnHover": "Video-Vorschau beim Hovern",
-        "expandDescription": "Beschreibung standardmäßig erweitern",
-        "expandComments": "Kommentare standardmäßig erweitern",
-        "dataPreferences": {
-            "content": "Sie möchten Abonnements importieren/exportieren, Ihr Passwort ändern oder Ihr Konto löschen? Klicken Sie hier und scrollen Sie bis zum Ende der Seite.",
-            "dataPreferences": "Dateneinstellungen"
-        },
-        "player": {
-            "title": "Player",
-            "autoPlay": "Video automatisch abspielen",
-            "alwaysLoopVideo": "Video immer in Schleife abspielen",
-            "savePlaybackPosition": "Wiedergabeposition speichern",
-            "listenByDefault": "Standardmäßig zuhören",
-            "theatreModeByDefault": "Standardmäßiger Theatermodus",
-            "autoPlayNextByDefault": "Standardmäßige Wiedergabe des nächsten Videos",
-            "miniPlayer": "Miniplayer",
-            "proxyVideos": "Proxy-Videos",
-            "backgroundPlay": "Ton im Hintergrund abspielen",
-            "dash": "Bindestrich"
-        },
-        "bookmarklet": "Lesezeichen",
-        "instanceUrl": "URL der Instanz",
-        "sponsors": {
-            "sponsor": "Sponsor",
-            "unpaidSelfPromotion": "Unbezahlte / Selbstständige Förderung",
-            "interactionReminder": "Interaktionserinnerung (Abonnieren)",
-            "intermissionIntroAnimation": "Unterbrechung/Einstiegsanimation",
-            "credits": "Endkarten/Gutschriften",
-            "preViewRecapHook": "Vorschau/Rückblick/Hook",
-            "tangentJokes": "Füller Tangent/Witze"
-        },
-        "deArrow": {
-            "title": "DeArrow",
-            "thumbnailInstanceUrl": "URL der Miniaturansicht",
-            "titleOnly": "Nur Titel"
-        }
-    },
-    "subscribe": "Abonnieren"
+	"enabled": "Aktiviert",
+	"copyUrl": "URL kopieren",
+	"loadMore": "Mehr laden",
+	"views": "Ansichten",
+	"invidiousBlockWarning": "Invidious wird derzeit von Google blockiert. Wenn Videos für diese Instanz nicht geladen werden, verwenden Sie diese Instanz bitte auf Materialious auf {android} oder {desktop}, um dies mit lokalem Videozurückfall zu umgehen.",
+	"videos": "Videos",
+	"cancel": "Abbrechen",
+	"create": "Erstellen",
+	"title": "Titel",
+	"searchPlaceholder": "Suchen...",
+	"delete": "Löschen",
+	"donate": "Spenden",
+	"deleteAllHistory": "Gesamten Verlauf löschen",
+	"skipping": "Überspringen",
+	"replies": "antworten",
+	"region": "Region",
+	"noResult": "Keine Ergebnisse",
+	"language": "Sprache",
+	"channels": "Kanäle",
+	"transcript": "Transkript",
+	"noCaptionData": "Untertitel enthalten keine daten.",
+	"selectLang": "Sprache auswählen",
+	"letterCase": "Groß-/Kleinschreibung für Titel",
+	"hideReplies": "Antworten verstecken",
+	"hideVideo": "Video verstecken",
+	"syncParty": {
+		"userJoined": "Ein Benutzer ist Ihrer Watch-Party beigetreten.",
+		"userLeft": "Ein Benutzer hat ihre Watch-Party verlassen.",
+		"userOnPrivatePage": "Der Benutzer sieht gerade eine private Seite, die Synchronisierung wird in Kürze fortgesetzt."
+	},
+	"videoTabs": {
+		"all": "Alle",
+		"videos": "Videos",
+		"playlists": "Wiedergabeliste",
+		"channels": "Kanäle",
+		"shorts": "Shorts",
+		"streams": "Ströme"
+	},
+	"subscriptions": {
+		"manageSubscriptions": "Abonnements verwalten"
+	},
+	"playlist": {
+		"createPlaylist": "Wiedergabeliste erstellen",
+		"public": "Öffentlich",
+		"unlisted": "Ungelistet",
+		"private": "Privat",
+		"playVideos": "Videos abspielen",
+		"shuffleVideos": "Videos in zufälliger Reihenfolge abspielen",
+		"loopPlaylist": "Wiedergabeliste in Schleife abspielen"
+	},
+	"thumbnail": {
+		"live": "LIVE",
+		"failedToLoadImage": "Laden des Bildes fehlgeschlagen"
+	},
+	"pages": {
+		"home": "Startseite",
+		"trending": "Beliebt",
+		"subscriptions": "Abonnements",
+		"history": "Verlauf",
+		"playlists": "Wiedergabelisten"
+	},
+	"subscribers": "Abonnenten",
+	"unsubscribe": "Deabonnieren",
+	"loginRequired": "Anmeldung erforderlich",
+	"player": {
+		"audioOnly": "Nur Ton",
+		"theatreMode": "Theatermodus",
+		"pauseTimer": "Timer pausieren",
+		"pauseVideoIn": "Video pausieren in ",
+		"share": {
+			"title": "Teilen",
+			"materialiousLink": "Materialious link kopieren",
+			"invidiousRedirect": "Invidious Weiterleitungslink kopieren",
+			"youtubeLink": "YouTube Link kopieren"
+		},
+		"download": "Herunterladen",
+		"downloadSteps": {
+			"merging": "Video und Audio zusammenführen",
+			"video": "Herunterladen der Video",
+			"audio": "Herunterladen der Audio",
+			"ffmpeg": "Herunterladen der ffmpeg-Bibliothek und -Komponenten",
+			"classWorker": "Herunterladen des ffmpeg-Klassenarbeiters",
+			"core": "Herunterladen der ffmpeg-Kern",
+			"wasm": "Herunterladen der ffmpeg wasm",
+			"worker": "Herunterladen der ffmpeg worker"
+		},
+		"noPlaylists": "Keine Wiedergabelisten",
+		"unableToLoadComments": "Laden der Kommentare fehlgeschlagen",
+		"addToPlaylist": "Zur Wiedergabeliste hinzufügen",
+		"youtubeJsFallBack": "Lokales Videozurückfall wird verwendet"
+	},
+	"layout": {
+		"interface": "Schnittstelle",
+		"star": "Sternchen auf GitHub vergeben",
+		"syncParty": "Synchronisierung der Partei",
+		"syncPartyWarning": "Bitte beachten Sie, dass Ihre IP für die von Ihnen eingeladenen Benutzer sichtbar ist.",
+		"startSyncParty": "Synchronisierung der Partei starten",
+		"endSyncParty": "Synchronisierung der Partei beenden",
+		"notifications": "Benachrichtigungen",
+		"noNewNotifications": "Keine neuen Benachrichtigungen",
+		"settings": "Einstellungen",
+		"login": "Anmelden",
+		"logout": "Abmelden",
+		"customize": "Anpassen",
+		"lowBandwidthMode": "Modus der geringer Bandbreite",
+		"theme": {
+			"theme": "Thema",
+			"darkMode": "Dunkler Modus",
+			"lightMode": "Heller Modus",
+			"AmoledTheme": "Amoled-Thema",
+			"color": "Farbe"
+		},
+		"searchSuggestions": "Suchvorschläge",
+		"previewVideoOnHover": "Video-Vorschau beim Hovern",
+		"expandDescription": "Beschreibung standardmäßig erweitern",
+		"expandComments": "Kommentare standardmäßig erweitern",
+		"dataPreferences": {
+			"content": "Sie möchten Abonnements importieren/exportieren, Ihr Passwort ändern oder Ihr Konto löschen? Klicken Sie hier und scrollen Sie bis zum Ende der Seite.",
+			"dataPreferences": "Dateneinstellungen"
+		},
+		"player": {
+			"title": "Spieler",
+			"autoPlay": "Video automatisch abspielen",
+			"alwaysLoopVideo": "Video immer in Schleife abspielen",
+			"savePlaybackPosition": "Wiedergabeposition speichern",
+			"listenByDefault": "Standardmäßig zuhören",
+			"theatreModeByDefault": "Standardmäßiger Theatermodus",
+			"autoPlayNextByDefault": "Standardmäßige Wiedergabe des nächsten Videos",
+			"miniPlayer": "Minispieler",
+			"proxyVideos": "Proxy-Videos",
+			"backgroundPlay": "Ton im Hintergrund abspielen",
+			"dash": "Bindestrich",
+			"silenceSkipper": "Schweigenüberspringer (Experimentell)",
+			"youtubeJsFallback": "Fallback für lokale Videoverarbeitung",
+			"youtubeJsAlways": "Verwenden Sie immer die lokale Videoverarbeitung",
+			"lockOrientation": "Ausrichtung an Seitenverhältnis gebunden"
+		},
+		"bookmarklet": "Lesezeichen",
+		"instanceUrl": "URL der Instanz",
+		"sponsors": {
+			"sponsor": "Sponsor",
+			"disableToast": "Toast deaktivieren",
+			"disableTimeline": "Segmente auf der Zeitleiste deaktivieren",
+			"Catagories": "Kategorien",
+			"unpaidSelfPromotion": "Unbezahlte / Selbstständige Förderung",
+			"interactionReminder": "Interaktionserinnerung (Abonnieren)",
+			"intermissionIntroAnimation": "Unterbrechung/Einstiegsanimation",
+			"credits": "Endkarten/Gutschriften",
+			"preViewRecapHook": "Vorschau/Rückblick/Hook",
+			"tangentJokes": "Füller Tangent/Witze"
+		},
+		"deArrow": {
+			"title": "DeArrow",
+			"thumbnailInstanceUrl": "URL der Miniaturansicht",
+			"titleOnly": "Nur Titel"
+		}
+	},
+	"subscribe": "Abonnieren"
 }

--- a/materialious/src/lib/i18n/locales/en.json
+++ b/materialious/src/lib/i18n/locales/en.json
@@ -142,7 +142,7 @@
 			"sponsor": "Sponsor",
 			"disableToast": "Disable toast",
 			"disableTimeline": "Disable segments on timeline",
-			"Catagories": "Catagories",
+			"Catagories": "Categories",
 			"unpaidSelfPromotion": "Unpaid/Self Promotion",
 			"interactionReminder": "Interaction Reminder (Subscribe)",
 			"intermissionIntroAnimation": "Intermission/Intro Animation",

--- a/materialious/src/lib/i18n/locales/nl.json
+++ b/materialious/src/lib/i18n/locales/nl.json
@@ -27,7 +27,7 @@
 	"syncParty": {
 		"userJoined": "De gebruiker heeft zich aangesloten bij jouw kijkgroep.",
 		"userLeft": "De gebruiker heeft je kijkgroep verlaten.",
-		"userOnPrivatePage": "De gebruiker bekijkt momenteel een privépagina. De synchronisatie wordt binnenkort hervat."
+		"userOnPrivatePage": "De gebruiker wie bekijkt momenteel een privépagina, de synchronisatie wordt binnenkort hervat."
 	},
 	"videoTabs": {
 		"all": "Alle",

--- a/materialious/src/lib/i18n/locales/nl.json
+++ b/materialious/src/lib/i18n/locales/nl.json
@@ -1,0 +1,160 @@
+{
+	"enabled": "Ingeschakeld",
+	"copyUrl": "URL kopiëren",
+	"loadMore": "Meer laden",
+	"views": "uitzichten",
+	"invidiousBlockWarning": "Invidious wordt momenteel geblokkeerd door Google. Als video's niet worden geladen voor deze instantie, gebruik dan deze instantie op Materialious op {android} of {desktop} om dit te omzeilen met lokale video terugval.",
+	"videos": "video's",
+	"cancel": "Annuleren",
+	"create": "Creëren",
+	"title": "Titel",
+	"searchPlaceholder": "Zoeken...",
+	"delete": "Verwijderen",
+	"donate": "Doneren",
+	"deleteAllHistory": "Alle geschiedenis verwijderen",
+	"skipping": "Overslaan",
+	"replies": "antwoorden",
+	"region": "Regio",
+	"noResult": "Geen resultaten",
+	"language": "Taal",
+	"channels": "kanalen",
+	"transcript": "Transcriptie",
+	"noCaptionData": "Ondertitels hebben geen gegevens.",
+	"selectLang": "Selecteer taal",
+	"letterCase": "Letterkast voor titels",
+	"hideReplies": "Antwoorden verbergen",
+	"hideVideo": "Video verbergen",
+	"syncParty": {
+		"userJoined": "De gebruiker heeft zich aangesloten bij jouw kijkgroep.",
+		"userLeft": "De gebruiker heeft je kijkgroep verlaten.",
+		"userOnPrivatePage": "De gebruiker bekijkt momenteel een privépagina. De synchronisatie wordt binnenkort hervat."
+	},
+	"videoTabs": {
+		"all": "Alle",
+		"videos": "Video's",
+		"playlists": "Afspeellijsten",
+		"channels": "Kanalen",
+		"shorts": "Shorts",
+		"streams": "Stromen"
+	},
+	"subscriptions": {
+		"manageSubscriptions": "Beheer abonnementen"
+	},
+	"playlist": {
+		"createPlaylist": "Maak een afspeellijst",
+		"public": "Openbaar",
+		"unlisted": "Onvermelde",
+		"private": "Privé",
+		"playVideos": "Video's afspelen",
+		"shuffleVideos": "Video's in willekeurige volgorde afspelen",
+		"loopPlaylist": "Herhaal afspeellijst"
+	},
+	"thumbnail": {
+		"live": "LIVE",
+		"failedToLoadImage": "Afbeelding laden mislukt"
+	},
+	"pages": {
+		"home": "Startpagina",
+		"trending": "Populair",
+		"subscriptions": "Abonnementen",
+		"history": "Geschiedenis",
+		"playlists": "Afspeellijsten"
+	},
+	"subscribers": "abonnees",
+	"unsubscribe": "Uitschrijven",
+	"loginRequired": "Inloggen vereist",
+	"player": {
+		"audioOnly": "Alleen audio",
+		"theatreMode": "Theatermodus",
+		"pauseTimer": "Pauzeer timer",
+		"pauseVideoIn": "Pauzeer video in ",
+		"share": {
+			"title": "Deel",
+			"materialiousLink": "Kopieer Materialious-link",
+			"invidiousRedirect": "Kopieer Invidious-omleidingslink",
+			"youtubeLink": "Kopieer Youtube-link"
+		},
+		"download": "Download",
+		"downloadSteps": {
+			"merging": "Video en audio samenvoegen",
+			"video": "Video downloaden",
+			"audio": "Audio downloaden",
+			"ffmpeg": "Downloaden van ffmpeg-bibliotheek en componenten",
+			"classWorker": "Downloaden van ffmpeg-klassewerker",
+			"core": "Downloaden van ffmpeg-kern",
+			"wasm": "Downloaden van ffmpeg wasm",
+			"worker": "Downloaden van ffmpeg-werker"
+		},
+		"noPlaylists": "Geen afspeellijsten",
+		"unableToLoadComments": "Kan opmerkingen niet laden",
+		"addToPlaylist": "Toevoegen aan afspeellijst",
+		"youtubeJsFallBack": "Lokale video terugval wordt gebruikt"
+	},
+	"layout": {
+		"interface": "Koppelvlak",
+		"star": "Geef ons een ster op Github!",
+		"syncParty": "Synchroniseren van partij",
+		"syncPartyWarning": "Houd er rekening mee dat uw IP-adres zichtbaar is voor gebruikers die u uitnodigt.",
+		"startSyncParty": "Start synchroniseren van partij",
+		"endSyncParty": "Einde synchroniseren van partij",
+		"notifications": "Meldingen",
+		"noNewNotifications": "Geen nieuwe meldingen hier",
+		"settings": "Instellingen",
+		"login": "Aanmelden",
+		"logout": "Afmelden",
+		"customize": "Aanpassen",
+		"lowBandwidthMode": "Lage bandbreedtemodus",
+		"theme": {
+			"theme": "Thema",
+			"darkMode": "Donkere modus",
+			"lightMode": "Lichtmodus",
+			"AmoledTheme": "Amoled-thema",
+			"color": "Kleur"
+		},
+		"searchSuggestions": "Zoek suggesties",
+		"previewVideoOnHover": "Voorbeeldvideo bij hover",
+		"expandDescription": "Beschrijving standaard uitvouwen",
+		"expandComments": "Standaard opmerkingen uitvouwen",
+		"dataPreferences": {
+			"content": "Wilt u abonnementen importeren/exporteren, wachtwoord wijzigen of account verwijderen? Klik hier en scroll naar de onderkant van de pagina.",
+			"dataPreferences": "Gegevensvoorkeuren"
+		},
+		"player": {
+			"title": "Speler",
+			"autoPlay": "Video automatisch afspelen",
+			"alwaysLoopVideo": "Video altijd herhalen",
+			"savePlaybackPosition": "Afspeelpositie opslaan",
+			"listenByDefault": "Standaard luisteren",
+			"theatreModeByDefault": "Theatermodus standaard",
+			"autoPlayNextByDefault": "Automatisch afspelen als volgende standaard",
+			"miniPlayer": "Mini-speler",
+			"proxyVideos": "Proxy-video's",
+			"backgroundPlay": "Audio op de achtergrond afspelen",
+			"dash": "Streepje-modus",
+			"silenceSkipper": "Stilte-overslager (Experimenteel)",
+			"youtubeJsFallback": "Lokale videoverwerking fallback",
+			"youtubeJsAlways": "Gebruik altijd lokale videoverwerking",
+			"lockOrientation": "Oriëntatie vergrendeld op beeldverhouding"
+		},
+		"bookmarklet": "Bladwijzer",
+		"instanceUrl": "Instantie-URL",
+		"sponsors": {
+			"sponsor": "Sponsor",
+			"disableToast": "Toast uitschakelen",
+			"disableTimeline": "Segmenten op tijdlijn uitschakelen",
+			"Catagories": "Categorieën",
+			"unpaidSelfPromotion": "Onbetaald/Zelfpromotie",
+			"interactionReminder": "Interactieherinnering (Abonneren)",
+			"intermissionIntroAnimation": "Pauze/Intro-animatie",
+			"credits": "Eindkaarten/credits",
+			"preViewRecapHook": "Voorbeschouwing/Samenvatting/Haak",
+			"tangentJokes": "Vulling Tangens/Grappen"
+		},
+		"deArrow": {
+			"title": "DeArrow",
+			"thumbnailInstanceUrl": "URL van miniatuurinstantie",
+			"titleOnly": "Alleen titel"
+		}
+	},
+	"subscribe": "Abonneren"
+}

--- a/materialious/src/lib/i18n/locales/ru.json
+++ b/materialious/src/lib/i18n/locales/ru.json
@@ -1,134 +1,134 @@
 {
-    "enabled": "Включено",
-    "copyUrl": "Копировать ссылку",
-    "loadMore": "Загрузить ещё",
-    "views": "просмотров",
-    "videos": "видео",
-    "cancel": "Отмена",
-    "create": "Создать",
-    "title": "Заголовок",
-    "searchPlaceholder": "Искать...",
-    "delete": "Удалить",
-    "deleteAllHistory": "Удалить всю историю",
-    "skipping": "Пропускаю",
-    "replies": "ответ(а/ов)",
-    "region": "Регион",
-    "noResult": "Без результатов",
-    "language": "Язык",
-    "transcript": "Транскрипция",
-    "noCaptionData": "Субтитры не содержат данных.",
-    "selectLang": "Выбрать язык",
-    "letterCase": "Регистр для названий",
-    "hideReplies": "Скрыть ответы",
-    "hideVideo": "Скрыть видео",
-    "syncParty": {
-        "userJoined": "Пользователь вошел в вашу группу",
-        "userLeft": "Пользователь покинул вашу группу",
-        "userOnPrivatePage": "Сейчас пользователь просматривает приватную страницу, синхронизация вскоре возобновится."
-    },
-    "videoTabs": {
-        "all": "Всё",
-        "videos": "Видео",
-        "playlists": "Списки воспроизведения",
-        "channels": "Каналы",
-        "shorts": "Shorts",
-        "streams": "Трансляции"
-    },
-    "subscriptions": {
-        "manageSubscriptions": "Управление подписками"
-    },
-    "playlist": {
-        "createPlaylist": "Создать список воспроизведения",
-        "public": "Общедоступно",
-        "unlisted": "Недоступно",
-        "private": "Ограниченно",
-        "playVideos": "Воспроизвести видео",
-        "shuffleVideos": "Воспроизвести видео в случайном порядке",
-        "loopPlaylist": "Повторять список воспроизведения"
-    },
-    "thumbnail": {
-        "live": "В ЭФИРЕ",
-        "failedToLoadImage": "Ошибка загрузки изображения"
-    },
-    "pages": {
-        "home": "Главная",
-        "trending": "В тренде",
-        "subscriptions": "Подписки",
-        "history": "История",
-        "playlists": "Плейлисты"
-    },
-    "subscribers": "подписчик(а/ов)",
-    "unsubscribe": "Отписаться",
-    "loginRequired": "Нужно войти в учётную запись",
-    "player": {
-        "audioOnly": "Только звук",
-        "theatreMode": "Широкий экран",
-        "share": {
-            "title": "Поделиться",
-            "materialiousLink": "Скопировать ссылку на Materialious",
-            "invidiousRedirect": "Скопировать ссылку на инстанс Invidious",
-            "youtubeLink": "Скопировать ссылку на Youtube"
-        },
-        "download": "Скачать",
-        "noPlaylists": "Нет списков воспроизведения",
-        "unableToLoadComments": "Невозможно загрузить комментарии",
-        "addToPlaylist": "Добавить в плейлист"
-    },
-    "layout": {
-        "star": "Поставить нам звезду на GitHub!",
-        "syncParty": "Совместный просмотр",
-        "syncPartyWarning": "Помните, ваш IP должен быть доступен для тех кого вы приглашаете.",
-        "startSyncParty": "Начать совместный просмотр",
-        "endSyncParty": "Закончить совместный просмотр",
-        "notifications": "Уведомления",
-        "noNewNotifications": "Нет новых уведомлений",
-        "settings": "Настройки",
-        "login": "Зайти в учетную запись",
-        "logout": "Выйти из учетной записи",
-        "customize": "Настроить под себя",
-        "theme": {
-            "theme": "Тема",
-            "darkMode": "Тёмный режим",
-            "lightMode": "Светлый режим",
-            "color": "Цвет"
-        },
-        "searchSuggestions": "Поисковые подсказки",
-        "previewVideoOnHover": "Предпросмотр видео при наведении",
-        "expandDescription": "Развернуть описание по умолчанию",
-        "expandComments": "Развернуть комментарий по умолчанию",
-        "dataPreferences": {
-            "content": "Ищете импорт/экспорт подписок, смену пароля или как удалить учётную запись? Нажмите сюда и прокрутите станицу вниз.",
-            "dataPreferences": "Настройки данных"
-        },
-        "player": {
-            "title": "Плеер",
-            "autoPlay": "Авто-воспроизведение видео",
-            "alwaysLoopVideo": "Зацикливать видео",
-            "savePlaybackPosition": "Сохранять позицию",
-            "listenByDefault": "Слушать по умолчанию",
-            "theatreModeByDefault": "Широкий формат по умолчанию",
-            "autoPlayNextByDefault": "Авто-воспроизведение по умолчанию",
-            "miniPlayer": "Мини-плеер",
-            "proxyVideos": "Прокси видео",
-            "backgroundPlay": "Играть аудио в фоне",
-            "dash": "Использовать DASH"
-        },
-        "bookmarklet": "Закладка",
-        "instanceUrl": "URL инстанса",
-        "sponsors": {
-            "sponsor": "Спонсор",
-            "unpaidSelfPromotion": "Самореклама",
-            "interactionReminder": "Напоминание о подписке",
-            "intermissionIntroAnimation": "Интро",
-            "credits": "Титры/Авторы",
-            "preViewRecapHook": "Краткое содержание",
-            "tangentJokes": "Шутки"
-        },
-        "deArrow": {
-            "title": "DeArrow",
-            "thumbnailInstanceUrl": "URL инстанса обложек",
-            "titleOnly": "Только название"
-        }
-    },
-    "subscribe": "Подписаться"
+	"enabled": "Включено",
+	"copyUrl": "Копировать ссылку",
+	"loadMore": "Загрузить ещё",
+	"views": "просмотров",
+	"videos": "видео",
+	"cancel": "Отмена",
+	"create": "Создать",
+	"title": "Заголовок",
+	"searchPlaceholder": "Искать...",
+	"delete": "Удалить",
+	"deleteAllHistory": "Удалить всю историю",
+	"skipping": "Пропускаю",
+	"replies": "ответ(а/ов)",
+	"region": "Регион",
+	"noResult": "Без результатов",
+	"language": "Язык",
+	"transcript": "Транскрипция",
+	"noCaptionData": "Субтитры не содержат данных.",
+	"selectLang": "Выбрать язык",
+	"letterCase": "Регистр для названий",
+	"hideReplies": "Скрыть ответы",
+	"hideVideo": "Скрыть видео",
+	"syncParty": {
+		"userJoined": "Пользователь вошел в вашу группу",
+		"userLeft": "Пользователь покинул вашу группу",
+		"userOnPrivatePage": "Сейчас пользователь просматривает приватную страницу, синхронизация вскоре возобновится."
+	},
+	"videoTabs": {
+		"all": "Всё",
+		"videos": "Видео",
+		"playlists": "Списки воспроизведения",
+		"channels": "Каналы",
+		"shorts": "Shorts",
+		"streams": "Трансляции"
+	},
+	"subscriptions": {
+		"manageSubscriptions": "Управление подписками"
+	},
+	"playlist": {
+		"createPlaylist": "Создать список воспроизведения",
+		"public": "Общедоступно",
+		"unlisted": "Недоступно",
+		"private": "Ограниченно",
+		"playVideos": "Воспроизвести видео",
+		"shuffleVideos": "Воспроизвести видео в случайном порядке",
+		"loopPlaylist": "Повторять список воспроизведения"
+	},
+	"thumbnail": {
+		"live": "В ЭФИРЕ",
+		"failedToLoadImage": "Ошибка загрузки изображения"
+	},
+	"pages": {
+		"home": "Главная",
+		"trending": "В тренде",
+		"subscriptions": "Подписки",
+		"history": "История",
+		"playlists": "Плейлисты"
+	},
+	"subscribers": "подписчик(а/ов)",
+	"unsubscribe": "Отписаться",
+	"loginRequired": "Нужно войти в учётную запись",
+	"player": {
+		"audioOnly": "Только звук",
+		"theatreMode": "Широкий экран",
+		"share": {
+			"title": "Поделиться",
+			"materialiousLink": "Скопировать ссылку на Materialious",
+			"invidiousRedirect": "Скопировать ссылку на инстанс Invidious",
+			"youtubeLink": "Скопировать ссылку на Youtube"
+		},
+		"download": "Скачать",
+		"noPlaylists": "Нет списков воспроизведения",
+		"unableToLoadComments": "Невозможно загрузить комментарии",
+		"addToPlaylist": "Добавить в плейлист"
+	},
+	"layout": {
+		"star": "Поставить нам звезду на GitHub!",
+		"syncParty": "Совместный просмотр",
+		"syncPartyWarning": "Помните, ваш IP должен быть доступен для тех кого вы приглашаете.",
+		"startSyncParty": "Начать совместный просмотр",
+		"endSyncParty": "Закончить совместный просмотр",
+		"notifications": "Уведомления",
+		"noNewNotifications": "Нет новых уведомлений",
+		"settings": "Настройки",
+		"login": "Зайти в учетную запись",
+		"logout": "Выйти из учетной записи",
+		"customize": "Настроить под себя",
+		"theme": {
+			"theme": "Тема",
+			"darkMode": "Тёмный режим",
+			"lightMode": "Светлый режим",
+			"color": "Цвет"
+		},
+		"searchSuggestions": "Поисковые подсказки",
+		"previewVideoOnHover": "Предпросмотр видео при наведении",
+		"expandDescription": "Развернуть описание по умолчанию",
+		"expandComments": "Развернуть комментарий по умолчанию",
+		"dataPreferences": {
+			"content": "Ищете импорт/экспорт подписок, смену пароля или как удалить учётную запись? Нажмите сюда и прокрутите станицу вниз.",
+			"dataPreferences": "Настройки данных"
+		},
+		"player": {
+			"title": "Плеер",
+			"autoPlay": "Авто-воспроизведение видео",
+			"alwaysLoopVideo": "Зацикливать видео",
+			"savePlaybackPosition": "Сохранять позицию",
+			"listenByDefault": "Слушать по умолчанию",
+			"theatreModeByDefault": "Широкий формат по умолчанию",
+			"autoPlayNextByDefault": "Авто-воспроизведение по умолчанию",
+			"miniPlayer": "Мини-плеер",
+			"proxyVideos": "Прокси видео",
+			"backgroundPlay": "Играть аудио в фоне",
+			"dash": "Использовать DASH"
+		},
+		"bookmarklet": "Закладка",
+		"instanceUrl": "URL инстанса",
+		"sponsors": {
+			"sponsor": "Спонсор",
+			"unpaidSelfPromotion": "Самореклама",
+			"interactionReminder": "Напоминание о подписке",
+			"intermissionIntroAnimation": "Интро",
+			"credits": "Титры/Авторы",
+			"preViewRecapHook": "Краткое содержание",
+			"tangentJokes": "Шутки"
+		},
+		"deArrow": {
+			"title": "DeArrow",
+			"thumbnailInstanceUrl": "URL инстанса обложек",
+			"titleOnly": "Только название"
+		}
+	},
+	"subscribe": "Подписаться"
 }

--- a/materialious/src/lib/i18n/locales/sh.json
+++ b/materialious/src/lib/i18n/locales/sh.json
@@ -1,0 +1,160 @@
+{
+	"enabled": "Omogućeno",
+	"copyUrl": "Kopiraj URL",
+	"loadMore": "Učitaj više",
+	"views": "pogleda",
+	"invidiousBlockWarning": "Google trenutno blokira Invidious. Ako se video snimci ne učitavaju za ovu instancu, koristite ovu instancu na Materialious na {android} ili {desktop} da biste to zaobišli pomoću lokalnog video povlačenja.",
+	"videos": "video snimci",
+	"cancel": "Otkaži",
+	"create": "Kreiraj",
+	"title": "Naslov",
+	"searchPlaceholder": "Traži",
+	"delete": "Izbriši",
+	"donate": "Donirajte",
+	"deleteAllHistory": "Izbrišite svu historiju",
+	"skipping": "Preskakanje",
+	"replies": "odgovori",
+	"region": "Regija",
+	"noResult": "Nema rezultata",
+	"language": "Jezik",
+	"channels": "kanali",
+	"transcript": "Transkript",
+	"noCaptionData": "Podnaslovi nemaju nikakve podatke.",
+	"selectLang": "Izaberite jezik",
+	"letterCase": "Velika slova za naslove",
+	"hideReplies": "Sakrijte odgovore",
+	"hideVideo": "Sakrijte video",
+	"syncParty": {
+		"userJoined": "Korisnik se pridružio vašem udruženju za gledanje.",
+		"userLeft": "Korisnik se napustio vaše udruženje za gledanje.",
+		"userOnPrivatePage": "Korisnik koji trenutno gleda privatnu stranicu, sinkronizacija će se uskoro nastaviti."
+	},
+	"videoTabs": {
+		"all": "Sve",
+		"videos": "Video snimci",
+		"playlists": "Zapisi",
+		"channels": "Kanali",
+		"shorts": "Shorts",
+		"streams": "Tokovi"
+	},
+	"subscriptions": {
+		"manageSubscriptions": "Upravljajte pretplatama"
+	},
+	"playlist": {
+		"createPlaylist": "Kreirajte zapis",
+		"public": "Javan",
+		"unlisted": "Nenaveden",
+		"private": "Privatan",
+		"playVideos": "Pusti video zapise",
+		"shuffleVideos": "Video snimci su pom(ij)ešani",
+		"loopPlaylist": "Ponavljaj zapis"
+	},
+	"thumbnail": {
+		"live": "UŽIVO",
+		"failedToLoadImage": "Učitavanje slike nije usp(j)elo"
+	},
+	"pages": {
+		"home": "Početna",
+		"trending": "U trendu",
+		"subscriptions": "Pretplate",
+		"history": "Historija",
+		"playlists": "Zapisi"
+	},
+	"subscribers": "pretplatnici",
+	"unsubscribe": "Otkažite pretplatu",
+	"loginRequired": "Potrebna je prijava",
+	"player": {
+		"audioOnly": "Samo zvuk",
+		"theatreMode": "Režim bioskopa",
+		"pauseTimer": "Pauziraj vremem(j)er",
+		"pauseVideoIn": "Pauzirajte video u",
+		"share": {
+			"title": "Pod(ij)eli",
+			"materialiousLink": "Kopiraj Materijalious poveznicu",
+			"invidiousRedirect": "Kopiraj Invidious poveznicu za preusm(j)eravanje",
+			"youtubeLink": "Kopirajte Youtube poveznicu"
+		},
+		"download": "Preuzmi",
+		"downloadSteps": {
+			"merging": "Spajaju se video i audio zapisi zajedno",
+			"video": "Preuzimanje videa",
+			"audio": "Preuzimanje zvuka",
+			"ffmpeg": "Preuzimanje ffmpeg biblioteke i komponenata",
+			"classWorker": "Preuzimanje ffmpeg klasnog radnika",
+			"core": "Preuzimanje ffmpeg jezgra",
+			"wasm": "Preuzimanje ffmpeg wasm",
+			"worker": "Preuzimanje ffmpeg radnika"
+		},
+		"noPlaylists": "Nema zapisa",
+		"unableToLoadComments": "Nije moguće učitati komentare",
+		"addToPlaylist": "Dodaj na listu za reprodukciju",
+		"youtubeJsFallBack": "Koristi se rezervni lokalni video"
+	},
+	"layout": {
+		"interface": "Sučelje",
+		"star": "Ozv(j)ezdite nas na Github-u!",
+		"syncParty": "Sinkronizacija žurke",
+		"syncPartyWarning": "Čuvajte na umu da će vaša IP adresa biti vidljiva korisnicima koje pozovete.",
+		"startSyncParty": "Započni žurku za sinkronizaciju",
+		"endSyncParty": "Završi žurku za sinkronizaciju",
+		"notifications": "Obav(j)eštenja",
+		"noNewNotifications": "Ovd(j)e nema novih obav(j)eštenja",
+		"settings": "Podešavanja/Postavke",
+		"login": "Upis",
+		"logout": "Ispis",
+		"customize": "Prilagodite",
+		"lowBandwidthMode": "Režim niske propusnosti",
+		"theme": {
+			"theme": "Tema",
+			"darkMode": "Tamni režim",
+			"lightMode": "Sv(j)etli režim",
+			"AmoledTheme": "Amoled tema",
+			"color": "Boja"
+		},
+		"searchSuggestions": "Pr(ij)edlozi za pretragu",
+		"previewVideoOnHover": "Pregledajte video pri lebdenju",
+		"expandDescription": "Zadano proširite opis",
+		"expandComments": "Zadano proširite komentare",
+		"dataPreferences": {
+			"content": "Želite da uvezete/izvezete pretplate, prom(j)enite lozinku ili izbrišete nalog? Kliknite ovd(j)e i pomaknite se do dna stranice.",
+			"dataPreferences": "Podešavanja podataka"
+		},
+		"player": {
+			"title": "Plejer",
+			"autoPlay": "Automatska reprodukcija videa",
+			"alwaysLoopVideo": "Uv(ij)ek ponovite video",
+			"savePlaybackPosition": "Sačuvajte poziciju reprodukcije",
+			"listenByDefault": "Zadano slušajte",
+			"theatreModeByDefault": "Zadan je režim bioskopa",
+			"autoPlayNextByDefault": "Zadano sl(j)edeće pokrenite",
+			"miniPlayer": "Mini plejer",
+			"proxyVideos": "Proksi video snimci",
+			"backgroundPlay": "Pustite audio u pozadini",
+			"dash": "Dash mod",
+			"silenceSkipper": "Preskoknik tišine (eksperimentalno)",
+			"youtubeJsFallback": "Povlačaj za lokalnu obradu video zapisa",
+			"youtubeJsAlways": "Uv(ij)ek koristite lokalnu obradu video zapisa",
+			"lockOrientation": "Or(ij)entacija je zaključana u odnosu na om(j)er"
+		},
+		"bookmarklet": "Oznaka",
+		"instanceUrl": "URL instance",
+		"sponsors": {
+			"sponsor": "Sponzor",
+			"disableToast": "Onemogući tost",
+			"disableTimeline": "Onemogućite segmente na vremenskoj liniji",
+			"Catagories": "Kategorije",
+			"unpaidSelfPromotion": "Neplaćeno/samounapređenje",
+			"interactionReminder": "Pods(j)etnik o interakciji (Pretplatite se)",
+			"intermissionIntroAnimation": "Pauza/uvodna animacija",
+			"credits": "Završne špice/zasluge",
+			"preViewRecapHook": "Pregled/Rekapitulacija/Kuka",
+			"tangentJokes": "Nadoknadna tangenta/vicevi"
+		},
+		"deArrow": {
+			"title": "DeArrow",
+			"thumbnailInstanceUrl": "URL minijature za instance",
+			"titleOnly": "Samo naslov"
+		}
+	},
+	"subscribe": "Pretplatite se"
+}

--- a/materialious/src/lib/i18n/locales/tr.json
+++ b/materialious/src/lib/i18n/locales/tr.json
@@ -1,146 +1,146 @@
 {
-    "enabled": "Aktif et",
-    "copyUrl": "URLi kopyala",
-    "loadMore": "Daha fazlasını yükle",
-    "views": "görüntülenme",
-    "videos": "videolar",
-    "cancel": "İptal",
-    "create": "Oluştur",
-    "title": "Başlık",
-    "searchPlaceholder": "Ara...",
-    "delete": "Sil",
-    "deleteAllHistory": "Tüm geçmişi sil",
-    "skipping": "Atla",
-    "replies": "cevaplar",
-    "region": "Bölge",
-    "noResult": "Sonuç yok",
-    "language": "Dil",
-    "transcript": "Transkript",
-    "noCaptionData": "Altyazılarda herhangi bir veri yoktur.",
-    "selectLang": "Dil seçin",
-    "letterCase": "Başlıklar için harf durumu",
-    "hideReplies": "Cevapları gizle",
-    "hideVideo": "Videoyu gizle",
-    "syncParty": {
-        "userJoined": "Kullanıcı izleme partinize katıldı.",
-        "userLeft": "Kullanıcı izleme partinizden ayrıldı.",
-        "userOnPrivatePage": "Kullanıcı şu an gizli bir sayfa görüntülüyor, senkronizasyon birazdan devam edecek."
-    },
-    "videoTabs": {
-        "all": "Tümü",
-        "videos": "Videolar",
-        "playlists": "Oynatma listeleri",
-        "channels": "Kanallar",
-        "shorts": "Shorts",
-        "streams": "Canlı Yayınlar"
-    },
-    "subscriptions": {
-        "manageSubscriptions": "Abonelikleri Yönet"
-    },
-    "playlist": {
-        "createPlaylist": "Oynatma listesi oluştur",
-        "public": "Herkese açık",
-        "unlisted": "Liste dışı",
-        "private": "Gizli",
-        "playVideos": "Videoları oynat",
-        "shuffleVideos": "Videoları karışık oynat",
-        "loopPlaylist": "Çalma listesini tekrarla"
-    },
-    "thumbnail": {
-        "live": "CANLI",
-        "failedToLoadImage": "Resim yüklenemedi"
-    },
-    "pages": {
-        "home": "Ana Sayfa",
-        "trending": "Trendler",
-        "subscriptions": "Abonelikler",
-        "history": "Geçmiş",
-        "playlists": "Oynatma Listeleri"
-    },
-    "subscribers": "aboneler",
-    "unsubscribe": "Abonelikten çık",
-    "loginRequired": "Oturum açmak gereklidir",
-    "player": {
-        "audioOnly": "Sadece ses",
-        "theatreMode": "Tiyatro modu",
-        "share": {
-            "title": "Paylaş",
-            "materialiousLink": "Bağlantıyı Materialious a kopyala",
-            "invidiousRedirect": "Invidious yönlendirme bağlantısını kopyala",
-            "youtubeLink": "Youtube bağlantısını kopyala"
-        },
-        "download": "İndir",
-        "noPlaylists": "Oynatma listesi yok",
-        "unableToLoadComments": "Yorumlar yüklenemiyor",
-        "addToPlaylist": "Oynatma listesine ekle",
-        "downloadSteps": {
-            "merging": "Birlikte video ve ses birleştiriliyor",
-            "video": "Video indiriliyor",
-            "audio": "Ses indiriliyor",
-            "ffmpeg": "FFmpeg kütüphaneleri ve parçaları indiriliyor",
-            "core": "FFmpeg çekirdeği indiriliyor",
-            "wasm": "FFmpeg wasm indiriliyor",
-            "worker": "FFmpeg işcisi indiriliyor",
-            "classWorker": "FFmpeg sınıf işcisi indiriliyor"
-        }
-    },
-    "layout": {
-        "star": "Github'da bize yıldız verin!",
-        "syncParty": "Senkronizasyon partisi",
-        "syncPartyWarning": "Lütfen IP nizin davet ettiğiniz kullanıcılara görüneceğini unutmayın.",
-        "startSyncParty": "Senkronizasyon partisi başlat",
-        "endSyncParty": "Senkronizasyon partisini sonlandır",
-        "notifications": "Bildirimler",
-        "noNewNotifications": "Burada yeni bildirim yok",
-        "settings": "Ayarlar",
-        "login": "Giriş Yap",
-        "logout": "Çıkış Yap",
-        "customize": "Özelleştir",
-        "theme": {
-            "theme": "Tema",
-            "darkMode": "Koyu mod",
-            "lightMode": "Açık Mod",
-            "color": "Renk"
-        },
-        "searchSuggestions": "Önerileri ara",
-        "previewVideoOnHover": "Fareyle üzerine gelindiğinde videoyu ön izleyin",
-        "dataPreferences": {
-            "content": "Abonelikleri içe/dışa aktarmayı, şifreyi değiştirmeyi veya hesabı silmeyi mi istiyorsunuz? Buraya tıklayın ve sayfanın en altına gidin.",
-            "dataPreferences": "Veri tercihleri"
-        },
-        "player": {
-            "title": "Oynatıcı",
-            "autoPlay": "Otomatik oynatılan video",
-            "alwaysLoopVideo": "Videoyu her zaman tekrara al",
-            "savePlaybackPosition": "Oynatma konumunu kaydet",
-            "listenByDefault": "Varsayılan olarak dinle",
-            "theatreModeByDefault": "Varsayılan olarak tiyatro modu",
-            "autoPlayNextByDefault": "Sonrakini varsayılan olarak otomatik oynat",
-            "miniPlayer": "Mini oynatıcı",
-            "proxyVideos": "Vekil Sunucu videolar",
-            "backgroundPlay": "Arka planda ses çal",
-            "silenceSkipper": "Sessizlik atlayıcı (Deneysel)"
-        },
-        "bookmarklet": "Yer işareti",
-        "instanceUrl": "Instance URL",
-        "sponsors": {
-            "sponsor": "Sponsor",
-            "unpaidSelfPromotion": "Ücretsiz/Kişisel Promosyon",
-            "interactionReminder": "Etkileşim Hatırlatıcısı (Abone Ol)",
-            "intermissionIntroAnimation": "Ara/Giriş Animasyonu",
-            "credits": "Bitiş Kartları/Krediler",
-            "preViewRecapHook": "Önizleme/Özet/Kanca",
-            "tangentJokes": "Dolgu Tanjantı/Şakalar",
-            "Catagories": "Kategoriler"
-        },
-        "deArrow": {
-            "title": "DeArrow",
-            "thumbnailInstanceUrl": "Küçük resim görünüm URL'si",
-            "titleOnly": "Sadece başlık"
-        },
-        "interface": "Arayüz",
-        "expandDescription": "Açıklamayı varsayılan olarak genişlet",
-        "expandComments": "Yorumları varsayılan olarak genişlet"
-    },
-    "subscribe": "Abone Ol"
+	"enabled": "Aktif et",
+	"copyUrl": "URLi kopyala",
+	"loadMore": "Daha fazlasını yükle",
+	"views": "görüntülenme",
+	"videos": "videolar",
+	"cancel": "İptal",
+	"create": "Oluştur",
+	"title": "Başlık",
+	"searchPlaceholder": "Ara...",
+	"delete": "Sil",
+	"deleteAllHistory": "Tüm geçmişi sil",
+	"skipping": "Atla",
+	"replies": "cevaplar",
+	"region": "Bölge",
+	"noResult": "Sonuç yok",
+	"language": "Dil",
+	"transcript": "Transkript",
+	"noCaptionData": "Altyazılarda herhangi bir veri yoktur.",
+	"selectLang": "Dil seçin",
+	"letterCase": "Başlıklar için harf durumu",
+	"hideReplies": "Cevapları gizle",
+	"hideVideo": "Videoyu gizle",
+	"syncParty": {
+		"userJoined": "Kullanıcı izleme partinize katıldı.",
+		"userLeft": "Kullanıcı izleme partinizden ayrıldı.",
+		"userOnPrivatePage": "Kullanıcı şu an gizli bir sayfa görüntülüyor, senkronizasyon birazdan devam edecek."
+	},
+	"videoTabs": {
+		"all": "Tümü",
+		"videos": "Videolar",
+		"playlists": "Oynatma listeleri",
+		"channels": "Kanallar",
+		"shorts": "Shorts",
+		"streams": "Canlı Yayınlar"
+	},
+	"subscriptions": {
+		"manageSubscriptions": "Abonelikleri Yönet"
+	},
+	"playlist": {
+		"createPlaylist": "Oynatma listesi oluştur",
+		"public": "Herkese açık",
+		"unlisted": "Liste dışı",
+		"private": "Gizli",
+		"playVideos": "Videoları oynat",
+		"shuffleVideos": "Videoları karışık oynat",
+		"loopPlaylist": "Çalma listesini tekrarla"
+	},
+	"thumbnail": {
+		"live": "CANLI",
+		"failedToLoadImage": "Resim yüklenemedi"
+	},
+	"pages": {
+		"home": "Ana Sayfa",
+		"trending": "Trendler",
+		"subscriptions": "Abonelikler",
+		"history": "Geçmiş",
+		"playlists": "Oynatma Listeleri"
+	},
+	"subscribers": "aboneler",
+	"unsubscribe": "Abonelikten çık",
+	"loginRequired": "Oturum açmak gereklidir",
+	"player": {
+		"audioOnly": "Sadece ses",
+		"theatreMode": "Tiyatro modu",
+		"share": {
+			"title": "Paylaş",
+			"materialiousLink": "Bağlantıyı Materialious a kopyala",
+			"invidiousRedirect": "Invidious yönlendirme bağlantısını kopyala",
+			"youtubeLink": "Youtube bağlantısını kopyala"
+		},
+		"download": "İndir",
+		"downloadSteps": {
+			"merging": "Birlikte video ve ses birleştiriliyor",
+			"video": "Video indiriliyor",
+			"audio": "Ses indiriliyor",
+			"ffmpeg": "FFmpeg kütüphaneleri ve parçaları indiriliyor",
+			"classWorker": "FFmpeg sınıf işcisi indiriliyor",
+			"core": "FFmpeg çekirdeği indiriliyor",
+			"wasm": "FFmpeg wasm indiriliyor",
+			"worker": "FFmpeg işcisi indiriliyor"
+		},
+		"noPlaylists": "Oynatma listesi yok",
+		"unableToLoadComments": "Yorumlar yüklenemiyor",
+		"addToPlaylist": "Oynatma listesine ekle"
+	},
+	"layout": {
+		"interface": "Arayüz",
+		"star": "Github'da bize yıldız verin!",
+		"syncParty": "Senkronizasyon partisi",
+		"syncPartyWarning": "Lütfen IP nizin davet ettiğiniz kullanıcılara görüneceğini unutmayın.",
+		"startSyncParty": "Senkronizasyon partisi başlat",
+		"endSyncParty": "Senkronizasyon partisini sonlandır",
+		"notifications": "Bildirimler",
+		"noNewNotifications": "Burada yeni bildirim yok",
+		"settings": "Ayarlar",
+		"login": "Giriş Yap",
+		"logout": "Çıkış Yap",
+		"customize": "Özelleştir",
+		"theme": {
+			"theme": "Tema",
+			"darkMode": "Koyu mod",
+			"lightMode": "Açık Mod",
+			"color": "Renk"
+		},
+		"searchSuggestions": "Önerileri ara",
+		"previewVideoOnHover": "Fareyle üzerine gelindiğinde videoyu ön izleyin",
+		"expandDescription": "Açıklamayı varsayılan olarak genişlet",
+		"expandComments": "Yorumları varsayılan olarak genişlet",
+		"dataPreferences": {
+			"content": "Abonelikleri içe/dışa aktarmayı, şifreyi değiştirmeyi veya hesabı silmeyi mi istiyorsunuz? Buraya tıklayın ve sayfanın en altına gidin.",
+			"dataPreferences": "Veri tercihleri"
+		},
+		"player": {
+			"title": "Oynatıcı",
+			"autoPlay": "Otomatik oynatılan video",
+			"alwaysLoopVideo": "Videoyu her zaman tekrara al",
+			"savePlaybackPosition": "Oynatma konumunu kaydet",
+			"listenByDefault": "Varsayılan olarak dinle",
+			"theatreModeByDefault": "Varsayılan olarak tiyatro modu",
+			"autoPlayNextByDefault": "Sonrakini varsayılan olarak otomatik oynat",
+			"miniPlayer": "Mini oynatıcı",
+			"proxyVideos": "Vekil Sunucu videolar",
+			"backgroundPlay": "Arka planda ses çal",
+			"silenceSkipper": "Sessizlik atlayıcı (Deneysel)"
+		},
+		"bookmarklet": "Yer işareti",
+		"instanceUrl": "Instance URL",
+		"sponsors": {
+			"sponsor": "Sponsor",
+			"Catagories": "Kategoriler",
+			"unpaidSelfPromotion": "Ücretsiz/Kişisel Promosyon",
+			"interactionReminder": "Etkileşim Hatırlatıcısı (Abone Ol)",
+			"intermissionIntroAnimation": "Ara/Giriş Animasyonu",
+			"credits": "Bitiş Kartları/Krediler",
+			"preViewRecapHook": "Önizleme/Özet/Kanca",
+			"tangentJokes": "Dolgu Tanjantı/Şakalar"
+		},
+		"deArrow": {
+			"title": "DeArrow",
+			"thumbnailInstanceUrl": "Küçük resim görünüm URL'si",
+			"titleOnly": "Sadece başlık"
+		}
+	},
+	"subscribe": "Abone Ol"
 }

--- a/project.inlang/settings.json
+++ b/project.inlang/settings.json
@@ -3,6 +3,7 @@
   "languageTags": [
     "en",
     "de",
+    "nl",
     "ru",
     "tr"
   ],

--- a/project.inlang/settings.json
+++ b/project.inlang/settings.json
@@ -5,6 +5,7 @@
     "de",
     "nl",
     "ru",
+    "sh",
     "tr"
   ],
   "modules": [


### PR DESCRIPTION
Updated, changed, fixed, and filled in the blanks on the German translation.

Found one error in English. It's not "Catagories".

Also, added Dutch and Serbo-Croatian if that's acceptable.

Former I'm very proficient in just as well as English and German, I've added in the latter as the "sh" macro because it's much easier to manage than Croatian, Bosnian, Serbian and Montenegrin all separately.

What with their being barely any distinguishable difference in the app itself between the linguistic varieties to warrant a separate treatment.