### PR TITLE
Add frame scrubbing keyboard shortcuts

### DIFF
--- a/materialious/package-lock.json
+++ b/materialious/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "materialious",
-	"version": "1.9.19",
+	"version": "1.9.20",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "materialious",
-			"version": "1.9.19",
+			"version": "1.9.20",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@capacitor-community/electron": "^5.0.1",

--- a/materialious/src/lib/components/Player.svelte
+++ b/materialious/src/lib/components/Player.svelte
@@ -590,6 +590,22 @@
 			playerElement.playbackRate = playerElement.playbackRate + 0.25;
 			return false;
 		});
+		
+		Mousetrap.bind(',', () => {
+			if (!playerElement) return
+			
+			const currentTrack = player.getVariantTracks().find(track => track.active)
+			const frameTime = 1/(currentTrack?.frameRate || 30)
+			playerElement.currentTime -= frameTime
+		})
+
+		Mousetrap.bind('.', () => {
+			if (!playerElement) return
+			
+			const currentTrack = player.getVariantTracks().find(track => track.active)
+			const frameTime = 1/(currentTrack?.frameRate || 30)
+			playerElement.currentTime += frameTime
+		})
 
 		playerElement.addEventListener('pause', async () => {
 			savePlayerPos();


### PR DESCRIPTION
Added ',' and '.' keyboard shortcuts to the player for scrubbing frame by frame through a video, just like on YouTube. This video is useful for testing: https://www.youtube.com/watch?v=OLxY0HDakRk

Closes #666