### PR TITLE
Add option to disable automatic update install

### DIFF
--- a/materialious/android/app/build.gradle
+++ b/materialious/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "us.materialio.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 137
-        versionName "1.9.20"
+        versionCode 138
+        versionName "1.9.21"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/materialious/electron/materialious.metainfo.xml
+++ b/materialious/electron/materialious.metainfo.xml
@@ -72,7 +72,11 @@
     
     
     
-    <release version="1.9.20" date="2025-7-09">
+    
+    <release version="1.9.21" date="2025-7-21">
+      <url>https://github.com/Materialious/Materialious/releases/tag/1.9.21</url>
+    </release>
+<release version="1.9.20" date="2025-7-09">
       <url>https://github.com/Materialious/Materialious/releases/tag/1.9.20</url>
     </release>
 <release version="1.9.19" date="2025-7-08">

--- a/materialious/electron/package-lock.json
+++ b/materialious/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "Materialious",
-	"version": "1.9.19",
+	"version": "1.9.20",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "Materialious",
-			"version": "1.9.19",
+			"version": "1.9.20",
 			"license": "MIT",
 			"dependencies": {
 				"@capacitor-community/electron": "^5.0.0",

--- a/materialious/electron/package-lock.json
+++ b/materialious/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "Materialious",
-	"version": "1.9.20",
+	"version": "1.9.21",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "Materialious",
-			"version": "1.9.20",
+			"version": "1.9.21",
 			"license": "MIT",
 			"dependencies": {
 				"@capacitor-community/electron": "^5.0.0",

--- a/materialious/electron/package.json
+++ b/materialious/electron/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Materialious",
-	"version": "1.9.20",
+	"version": "1.9.21",
 	"description": "Modern material design for Invidious.",
 	"author": {
 		"name": "Ward Pearce",

--- a/materialious/electron/src/index.ts
+++ b/materialious/electron/src/index.ts
@@ -166,8 +166,16 @@ ipcMain.handle('setAllowInsecureSSL', async (_, allow) => {
 	return allowInsecureSSL;
 });
 
-ipcMain.handle('doUpdateCheck', (_, disableAutoUpdate) => {
+ipcMain.handle('doUpdateCheck', async (_, disableAutoUpdate) => {
 	// Check for updates if we are in a packaged app.
-	autoUpdater.autoInstallOnAppQuit = !disableAutoUpdate
-	autoUpdater.checkForUpdatesAndNotify();
-})
+	autoUpdater.autoInstallOnAppQuit = !disableAutoUpdate;
+
+	if (disableAutoUpdate) {
+		await autoUpdater.checkForUpdatesAndNotify({
+			title: 'Update Available',
+			body: 'A new version is available.'
+		});
+	} else {
+		await autoUpdater.checkForUpdatesAndNotify();
+	}
+});

--- a/materialious/electron/src/index.ts
+++ b/materialious/electron/src/index.ts
@@ -58,8 +58,6 @@ let allowInsecureSSL = false;
 	setupContentSecurityPolicy(myCapacitorApp.getCustomURLScheme());
 	// Initialize our app, build windows, and load content.
 	await myCapacitorApp.init();
-	// Check for updates if we are in a packaged app.
-	autoUpdater.checkForUpdatesAndNotify();
 })();
 
 app.on('certificate-error', (event, webContents, url, error, certificate, callback) => {
@@ -167,3 +165,9 @@ ipcMain.handle('setAllowInsecureSSL', async (_, allow) => {
 
 	return allowInsecureSSL;
 });
+
+ipcMain.handle('doUpdateCheck', (_, disableAutoUpdate) => {
+	// Check for updates if we are in a packaged app.
+	autoUpdater.autoInstallOnAppQuit = !disableAutoUpdate
+	autoUpdater.checkForUpdatesAndNotify();
+})

--- a/materialious/electron/src/preload.ts
+++ b/materialious/electron/src/preload.ts
@@ -8,5 +8,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
 		ipcRenderer.invoke('generatePoToken', bgChallenge, requestKey, visitorData),
 	setAllowInsecureSSL: async (allow: boolean) => {
 		return await ipcRenderer.invoke('setAllowInsecureSSL', allow);
-	}
+	},
+	doUpdateCheck: (disableAutoUpdate) => ipcRenderer.invoke('doUpdateCheck', disableAutoUpdate)
 });

--- a/materialious/package-lock.json
+++ b/materialious/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "materialious",
-	"version": "1.9.19",
+	"version": "1.9.20",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "materialious",
-			"version": "1.9.19",
+			"version": "1.9.20",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@capacitor-community/electron": "^5.0.1",

--- a/materialious/package-lock.json
+++ b/materialious/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "materialious",
-	"version": "1.9.20",
+	"version": "1.9.21",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "materialious",
-			"version": "1.9.20",
+			"version": "1.9.21",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@capacitor-community/electron": "^5.0.1",

--- a/materialious/package.json
+++ b/materialious/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "materialious",
-	"version": "1.9.20",
+	"version": "1.9.21",
 	"private": true,
 	"scripts": {
 		"dev": "vite dev",

--- a/materialious/src/app.d.ts
+++ b/materialious/src/app.d.ts
@@ -19,6 +19,7 @@ declare global {
 				visitorData: string
 			) => Promise<string>;
 			setAllowInsecureSSL: (allowInsecureSSL: boolean) => Promoise<boolean>;
+			doUpdateCheck: (disableAutoUpdate: boolean) => Promise<void>;
 		};
 	}
 }

--- a/materialious/src/lib/components/Settings/Interface.svelte
+++ b/materialious/src/lib/components/Settings/Interface.svelte
@@ -111,6 +111,12 @@
 		}
 	});
 
+	if (Capacitor.getPlatform() === 'electron') {
+		interfaceDisableAutoUpdate.subscribe((isDisabled) => {
+			window.electronAPI.doUpdateCheck(isDisabled);
+		});
+	}
+
 	let pages: Pages = $state([]);
 	authStore.subscribe(() => {
 		pages = getPages();

--- a/materialious/src/lib/components/Settings/Interface.svelte
+++ b/materialious/src/lib/components/Settings/Interface.svelte
@@ -21,6 +21,7 @@
 		interfaceAutoExpandComments,
 		interfaceAutoExpandDesc,
 		interfaceDefaultPage,
+		interfaceDisableAutoUpdate,
 		interfaceForceCase,
 		interfaceLowBandwidthMode,
 		interfaceRegionStore,
@@ -287,6 +288,24 @@
 		</label>
 	</nav>
 </div>
+
+{#if Capacitor.getPlatform() == 'electron'}
+	<div class="field no-margin">
+		<nav class="no-padding">
+			<div class="max">
+				<div>{$_('layout.disableAutoUpdate')}</div>
+			</div>
+			<label class="switch" tabindex="0" role="switch">
+				<input
+					type="checkbox"
+					bind:checked={$interfaceDisableAutoUpdate}
+					onclick={() => interfaceDisableAutoUpdate.set(!$interfaceDisableAutoUpdate)}
+				/>
+				<span></span>
+			</label>
+		</nav>
+	</div>
+{/if}
 
 <div class="field label suffix border">
 	<select

--- a/materialious/src/lib/i18n/locales/de.json
+++ b/materialious/src/lib/i18n/locales/de.json
@@ -124,6 +124,7 @@
         "previewVideoOnHover": "Video-Vorschau beim Hovern",
         "expandDescription": "Beschreibung standardmäßig erweitern",
         "expandComments": "Kommentare standardmäßig erweitern",
+        "disableAutoUpdate": "Automatische Installation von Updates deaktivieren",
         "dataPreferences": {
             "content": "Du möchtest Abonnements importieren/exportieren, dein Passwort ändern oder dein Konto löschen? Klicke hier und scrolle bis zum Ende der Seite.",
             "dataPreferences": "Dateneinstellungen"

--- a/materialious/src/lib/i18n/locales/en.json
+++ b/materialious/src/lib/i18n/locales/en.json
@@ -136,7 +136,7 @@
 		"expandChapters": "Expand chapters by default",
 		"expandComments": "Expand comments by default",
 		"allowInsecureRequests": "Allow insecure requests",
-		"disableAutoUpdate": "Disable automatic update installation",
+		"disableAutoUpdate": "Disable automatic updates",
 		"dataPreferences": {
 			"content": "Looking to import/export subscriptions, change password or delete account? Click here and scroll to the bottom of the page.",
 			"dataPreferences": "Data preferences"

--- a/materialious/src/lib/i18n/locales/en.json
+++ b/materialious/src/lib/i18n/locales/en.json
@@ -136,6 +136,7 @@
 		"expandChapters": "Expand chapters by default",
 		"expandComments": "Expand comments by default",
 		"allowInsecureRequests": "Allow insecure requests",
+		"disableAutoUpdate": "Disable automatic update installation",
 		"dataPreferences": {
 			"content": "Looking to import/export subscriptions, change password or delete account? Click here and scroll to the bottom of the page.",
 			"dataPreferences": "Data preferences"

--- a/materialious/src/lib/store.ts
+++ b/materialious/src/lib/store.ts
@@ -92,6 +92,7 @@ export const interfaceDisplayThumbnailAvatars = persisted('disableThumbnailAvata
 export const interfaceDefaultPage = persisted('defaultPage', '/');
 export const interfaceSearchHistoryEnabled = persisted('searchHistoryEnabled', false);
 export const interfaceAllowInsecureRequests = persisted('allowInsecureRequests', false);
+export const interfaceDisableAutoUpdate = persisted('disableAutoUpdate', false)
 
 export const sponsorBlockStore = persisted('sponsorBlock', true);
 export const sponsorBlockUrlStore: Writable<string | null | undefined> = persisted(

--- a/materialious/src/routes/(app)/+layout.svelte
+++ b/materialious/src/routes/(app)/+layout.svelte
@@ -20,6 +20,7 @@
 		instanceStore,
 		interfaceAmoledTheme,
 		interfaceDefaultPage,
+		interfaceDisableAutoUpdate,
 		isAndroidTvStore,
 		syncPartyPeerStore,
 		themeColorStore
@@ -210,6 +211,8 @@
 		if (isLoggedIn) {
 			loadNotifications().catch(() => authStore.set(null));
 		}
+
+		window.electronAPI.doUpdateCheck($interfaceDisableAutoUpdate)
 	});
 
 	function linkClickOverwrite(event: MouseEvent) {

--- a/materialious/src/routes/(app)/+layout.svelte
+++ b/materialious/src/routes/(app)/+layout.svelte
@@ -20,7 +20,6 @@
 		instanceStore,
 		interfaceAmoledTheme,
 		interfaceDefaultPage,
-		interfaceDisableAutoUpdate,
 		isAndroidTvStore,
 		syncPartyPeerStore,
 		themeColorStore
@@ -211,8 +210,6 @@
 		if (isLoggedIn) {
 			loadNotifications().catch(() => authStore.set(null));
 		}
-
-		window.electronAPI.doUpdateCheck($interfaceDisableAutoUpdate)
 	});
 
 	function linkClickOverwrite(event: MouseEvent) {

--- a/update_versions.py
+++ b/update_versions.py
@@ -3,7 +3,7 @@ import os
 import re
 from datetime import datetime
 
-LATEST_VERSION = "1.9.20"
+LATEST_VERSION = "1.9.21"
 RELEASE_DATE = datetime.now().strftime("%Y-%-m-%d")  # Format: YYYY-M-D
 
 WORKING_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "materialious")


### PR DESCRIPTION
Adds a new settings option in the interface section to disable the automatic installation of updates when installed as an Electron app. The setting defaults to false.

The update will still be downloaded to cache, but it won't be installed automatically any more. Known issue: the notification (sent by electron-updater itself) will still falsely claim that it will be auto-installed after app quit, but that's not the case with the option enabled. I think that's a tradeoff we can live with, as I wanted to keep it simple and not send the notification by ourselves.

Closes #832