### PR TITLE
Sync available locales with those translated

### DIFF
--- a/materialious/src/lib/i18n/index.ts
+++ b/materialious/src/lib/i18n/index.ts
@@ -7,6 +7,7 @@ export const locale: Writable<string> = writable(defaultLocale);
 export const _: Writable<(key: string, options?: any) => string> = writable(() => '');
 
 const resources: Record<string, () => Promise<Record<string, any>>> = {
+	ar: () => import('./locales/ar.json'),
 	en: () => import('./locales/en.json'),
 	ru: () => import('./locales/ru.json'),
 	'zh-CN': () => import('./locales/zh-CN.json'),
@@ -14,6 +15,7 @@ const resources: Record<string, () => Promise<Record<string, any>>> = {
 	nl: () => import('./locales/nl.json'),
 	de: () => import('./locales/de.json'),
 	es: () => import('./locales/es.json'),
+	gsw: () => import('./locales/gsw.json'),
 	sh: () => import('./locales/sh.json'),
 	'pt-BR': () => import('./locales/pt-BR.json'),
 	lv: () => import('./locales/lv.json'),

--- a/materialious/src/lib/i18n/locales/de.json
+++ b/materialious/src/lib/i18n/locales/de.json
@@ -124,7 +124,7 @@
         "previewVideoOnHover": "Video-Vorschau beim Hovern",
         "expandDescription": "Beschreibung standardmäßig erweitern",
         "expandComments": "Kommentare standardmäßig erweitern",
-        "disableAutoUpdate": "Automatische Installation von Updates deaktivieren",
+        "disableAutoUpdate": "Automatische Updates deaktivieren",
         "dataPreferences": {
             "content": "Du möchtest Abonnements importieren/exportieren, dein Passwort ändern oder dein Konto löschen? Klicke hier und scrolle bis zum Ende der Seite.",
             "dataPreferences": "Dateneinstellungen"

--- a/materialious/src/lib/i18n/locales/gsw.json
+++ b/materialious/src/lib/i18n/locales/gsw.json
@@ -85,7 +85,8 @@
         },
         "syncPartyWarning": "Bitte denk dra, dass dini IP für die vo dir iigladne Benutzer sichtbar isch.",
         "displayThumbnailAvatars": "Vorschaubild-Avatar (Langsam)",
-        "expandDescription": "Beschriibig standardmässig erwiitere"
+        "expandDescription": "Beschriibig standardmässig erwiitere",
+        "disableAutoUpdate": "Automatischi Updates deaktiviere"
     },
     "videos": "Videos",
     "cancel": "Abbreche",


### PR DESCRIPTION
Swiss German and Arabic are (for the most part) translated and are now available for display.