### PR TITLE
Fix border radius on video titles (#1032)

### DIFF
--- a/materialious/src/lib/components/Thumbnail.svelte
+++ b/materialious/src/lib/components/Thumbnail.svelte
@@ -270,6 +270,7 @@
 	.video-title {
 		word-wrap: break-word;
 		overflow: hidden;
+		border-radius: 0px;
 	}
 
 	.thumbnail-details {


### PR DESCRIPTION
Video titles had inherited a border radius that was causing the top left of the text to be clipped off. I added a line to the CSS definitions in the Thumbnail component to set the border-radius to 0px, which should fix the issue.

Close #1032 