### PR TITLE
Make sure fallback language is always loaded

### DIFF
--- a/materialious/src/lib/i18n/index.ts
+++ b/materialious/src/lib/i18n/index.ts
@@ -42,6 +42,7 @@ function getUserLocale(): string {
 export async function initI18n(selectedLocale: string = getUserLocale()): Promise<void> {
 	const langToLoad = resources[selectedLocale] ? selectedLocale : defaultLocale;
 	const translations = await resources[langToLoad]();
+	const fallbackTranslations = await resources[defaultLocale]();
 
 	const options: InitOptions = {
 		lng: langToLoad,
@@ -49,6 +50,9 @@ export async function initI18n(selectedLocale: string = getUserLocale()): Promis
 		resources: {
 			[langToLoad]: {
 				translation: translations.default || translations
+			},
+			[defaultLocale]: {
+				translation: fallbackTranslations.default || fallbackTranslations
 			}
 		}
 	};


### PR DESCRIPTION
Only the target language was being loaded into the client. This caused untranslated strings to be shown with their key instead of the fallback language (English). We now make sure to always load the default locale.

Fixes #1047