### PR TITLE
Improve switch and settings tabs accessibility

### DIFF
--- a/materialious/android/.idea/deviceManager.xml
+++ b/materialious/android/.idea/deviceManager.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DeviceTable">
+    <option name="columnSorters">
+      <list>
+        <ColumnSorterState>
+          <option name="column" value="Name" />
+          <option name="order" value="ASCENDING" />
+        </ColumnSorterState>
+      </list>
+    </option>
+  </component>
+</project>

--- a/materialious/package-lock.json
+++ b/materialious/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "materialious",
-	"version": "1.10.3",
+	"version": "1.10.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "materialious",
-			"version": "1.10.3",
+			"version": "1.10.4",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@capacitor-community/electron": "^5.0.1",

--- a/materialious/src/lib/components/Settings/ApiExtended.svelte
+++ b/materialious/src/lib/components/Settings/ApiExtended.svelte
@@ -29,11 +29,12 @@
 	<div class="max">
 		<p>{$_('enabled')}</p>
 	</div>
-	<label class="switch" tabindex="0" role="switch">
+	<label class="switch" tabindex="0">
 		<input
 			bind:checked={$synciousStore}
 			onclick={() => synciousStore.set(!$synciousStore)}
 			type="checkbox"
+			role="switch"
 		/>
 		<span></span>
 	</label>

--- a/materialious/src/lib/components/Settings/DeArrow.svelte
+++ b/materialious/src/lib/components/Settings/DeArrow.svelte
@@ -43,11 +43,12 @@
 	<div class="max">
 		<p>{$_('layout.deArrow.titleOnly')}</p>
 	</div>
-	<label class="switch" tabindex="0" role="switch">
+	<label class="switch" tabindex="0">
 		<input
 			bind:checked={$deArrowTitlesOnly}
 			onclick={() => deArrowTitlesOnly.set(!$deArrowTitlesOnly)}
 			type="checkbox"
+			role="switch"
 		/>
 		<span></span>
 	</label>
@@ -57,11 +58,12 @@
 	<div class="max">
 		<p>{$_('enabled')}</p>
 	</div>
-	<label class="switch" tabindex="0" role="switch">
+	<label class="switch" tabindex="0">
 		<input
 			bind:checked={$deArrowEnabledStore}
 			onclick={() => deArrowEnabledStore.set(!$deArrowEnabledStore)}
 			type="checkbox"
+			role="switch"
 		/>
 		<span></span>
 	</label>

--- a/materialious/src/lib/components/Settings/Interface.svelte
+++ b/materialious/src/lib/components/Settings/Interface.svelte
@@ -153,6 +153,7 @@
 						type="checkbox"
 						bind:checked={$interfaceAllowInsecureRequests}
 						onclick={allowInsecureRequests}
+						role="switch"
 					/>
 					<span></span>
 				</label>
@@ -184,11 +185,12 @@
 			<div class="max">
 				<div>{$_('layout.theme.AmoledTheme')}</div>
 			</div>
-			<label class="switch" tabindex="0" role="switch">
+			<label class="switch" tabindex="0">
 				<input
 					type="checkbox"
 					bind:checked={$interfaceAmoledTheme}
 					onclick={() => interfaceAmoledTheme.set(!$interfaceAmoledTheme)}
+					role="switch"
 				/>
 				<span></span>
 			</label>
@@ -201,7 +203,7 @@
 		<div class="max">
 			<div>{$_('layout.searchHistory')}</div>
 		</div>
-		<label class="switch" tabindex="0" role="switch">
+		<label class="switch" tabindex="0">
 			<input
 				type="checkbox"
 				bind:checked={$interfaceSearchHistoryEnabled}
@@ -209,6 +211,7 @@
 					interfaceSearchHistoryEnabled.set(!$interfaceSearchHistoryEnabled);
 					searchHistoryStore.set([]);
 				}}
+				role="switch"
 			/>
 			<span></span>
 		</label>
@@ -220,11 +223,12 @@
 		<div class="max">
 			<div>{$_('layout.lowBandwidthMode')}</div>
 		</div>
-		<label class="switch" tabindex="0" role="switch">
+		<label class="switch" tabindex="0">
 			<input
 				type="checkbox"
 				bind:checked={$interfaceLowBandwidthMode}
 				onclick={() => interfaceLowBandwidthMode.set(!$interfaceLowBandwidthMode)}
+				role="switch"
 			/>
 			<span></span>
 		</label>
@@ -236,11 +240,12 @@
 		<div class="max">
 			<div>{$_('layout.searchSuggestions')}</div>
 		</div>
-		<label class="switch" tabindex="0" role="switch">
+		<label class="switch" tabindex="0">
 			<input
 				type="checkbox"
 				bind:checked={$interfaceSearchSuggestionsStore}
 				onclick={() => interfaceSearchSuggestionsStore.set(!$interfaceSearchSuggestionsStore)}
+				role="switch"
 			/>
 			<span></span>
 		</label>
@@ -252,11 +257,12 @@
 		<div class="max">
 			<div>{$_('layout.expandDescription')}</div>
 		</div>
-		<label class="switch" tabindex="0" role="switch">
+		<label class="switch" tabindex="0">
 			<input
 				type="checkbox"
 				bind:checked={$interfaceAutoExpandDesc}
 				onclick={() => interfaceAutoExpandDesc.set(!$interfaceAutoExpandDesc)}
+				role="switch"
 			/>
 			<span></span>
 		</label>
@@ -268,11 +274,12 @@
 		<div class="max">
 			<div>{$_('layout.expandChapters')}</div>
 		</div>
-		<label class="switch" tabindex="0" role="switch">
+		<label class="switch" tabindex="0">
 			<input
 				type="checkbox"
 				bind:checked={$interfaceAutoExpandChapters}
 				onclick={() => interfaceAutoExpandChapters.set(!$interfaceAutoExpandChapters)}
+				role="switch"
 			/>
 			<span></span>
 		</label>
@@ -284,11 +291,12 @@
 		<div class="max">
 			<div>{$_('layout.expandComments')}</div>
 		</div>
-		<label class="switch" tabindex="0" role="switch">
+		<label class="switch" tabindex="0">
 			<input
 				type="checkbox"
 				bind:checked={$interfaceAutoExpandComments}
 				onclick={() => interfaceAutoExpandComments.set(!$interfaceAutoExpandComments)}
+				role="switch"
 			/>
 			<span></span>
 		</label>
@@ -301,11 +309,12 @@
 			<div class="max">
 				<div>{$_('layout.disableAutoUpdate')}</div>
 			</div>
-			<label class="switch" tabindex="0" role="switch">
+			<label class="switch" tabindex="0">
 				<input
 					type="checkbox"
 					bind:checked={$interfaceDisableAutoUpdate}
 					onclick={() => interfaceDisableAutoUpdate.set(!$interfaceDisableAutoUpdate)}
+					role="switch"
 				/>
 				<span></span>
 			</label>

--- a/materialious/src/lib/components/Settings/Player.svelte
+++ b/materialious/src/lib/components/Settings/Player.svelte
@@ -141,11 +141,12 @@
 		<div class="max">
 			<div>{$_('layout.player.ccByDefault')}</div>
 		</div>
-		<label class="switch" tabindex="0" role="switch">
+		<label class="switch" tabindex="0">
 			<input
 				type="checkbox"
 				bind:checked={$playerCCByDefault}
 				onclick={() => playerCCByDefault.set(!$playerCCByDefault)}
+				role="switch"
 			/>
 			<span></span>
 		</label>
@@ -157,11 +158,12 @@
 		<div class="max">
 			<div>{$_('layout.player.autoPlay')}</div>
 		</div>
-		<label class="switch" tabindex="0" role="switch">
+		<label class="switch" tabindex="0">
 			<input
 				type="checkbox"
 				bind:checked={$playerAutoPlayStore}
 				onclick={() => playerAutoPlayStore.set(!$playerAutoPlayStore)}
+				role="switch"
 			/>
 			<span></span>
 		</label>
@@ -173,11 +175,12 @@
 		<div class="max">
 			<div>{$_('layout.player.alwaysLoopVideo')}</div>
 		</div>
-		<label class="switch" tabindex="0" role="switch">
+		<label class="switch" tabindex="0">
 			<input
 				type="checkbox"
 				bind:checked={$playerAlwaysLoopStore}
 				onclick={() => playerAlwaysLoopStore.set(!$playerAlwaysLoopStore)}
+				role="switch"
 			/>
 			<span></span>
 		</label>
@@ -190,11 +193,12 @@
 			<div class="max">
 				<div>{$_('layout.player.lockOrientation')}</div>
 			</div>
-			<label class="switch" tabindex="0" role="switch">
+			<label class="switch" tabindex="0">
 				<input
 					type="checkbox"
 					bind:checked={$playerAndroidLockOrientation}
 					onclick={() => playerAndroidLockOrientation.set(!$playerAndroidLockOrientation)}
+					role="switch"
 				/>
 				<span></span>
 			</label>
@@ -208,11 +212,12 @@
 			<div class="max">
 				<div>{$_('layout.player.proxyVideos')}</div>
 			</div>
-			<label class="switch" tabindex="0" role="switch">
+			<label class="switch" tabindex="0">
 				<input
 					type="checkbox"
 					bind:checked={$playerProxyVideosStore}
 					onclick={() => playerProxyVideosStore.set(!$playerProxyVideosStore)}
+					role="switch"
 				/>
 				<span></span>
 			</label>
@@ -225,11 +230,12 @@
 		<div class="max">
 			<div>{$_('layout.player.savePlaybackPosition')}</div>
 		</div>
-		<label class="switch" tabindex="0" role="switch">
+		<label class="switch" tabindex="0">
 			<input
 				type="checkbox"
 				bind:checked={$playerSavePlaybackPositionStore}
 				onclick={() => playerSavePlaybackPositionStore.set(!$playerSavePlaybackPositionStore)}
+				role="switch"
 			/>
 			<span></span>
 		</label>
@@ -241,11 +247,12 @@
 		<div class="max">
 			<div>{$_('layout.player.theatreModeByDefault')}</div>
 		</div>
-		<label class="switch" tabindex="0" role="switch">
+		<label class="switch" tabindex="0">
 			<input
 				type="checkbox"
 				bind:checked={$playerTheatreModeByDefaultStore}
 				onclick={() => playerTheatreModeByDefaultStore.set(!$playerTheatreModeByDefaultStore)}
+				role="switch"
 			/>
 			<span></span>
 		</label>
@@ -257,11 +264,12 @@
 		<div class="max">
 			<div>{$_('layout.player.autoPlayNextByDefault')}</div>
 		</div>
-		<label class="switch" tabindex="0" role="switch">
+		<label class="switch" tabindex="0">
 			<input
 				type="checkbox"
 				bind:checked={$playerAutoplayNextByDefaultStore}
 				onclick={() => playerAutoplayNextByDefaultStore.set(!$playerAutoplayNextByDefaultStore)}
+				role="switch"
 			/>
 			<span></span>
 		</label>
@@ -273,11 +281,12 @@
 		<div class="max">
 			<div>{$_('layout.player.playerStatistics')}</div>
 		</div>
-		<label class="switch" tabindex="0" role="switch">
+		<label class="switch" tabindex="0">
 			<input
 				type="checkbox"
 				bind:checked={$playerStatisticsByDefault}
 				onclick={() => playerStatisticsByDefault.set(!playerStatisticsByDefault)}
+				role="switch"
 			/>
 			<span></span>
 		</label>

--- a/materialious/src/lib/components/Settings/RYD.svelte
+++ b/materialious/src/lib/components/Settings/RYD.svelte
@@ -29,11 +29,12 @@
 	<div class="max">
 		<p>{$_('enabled')}</p>
 	</div>
-	<label class="switch" tabindex="0" role="switch">
+	<label class="switch" tabindex="0">
 		<input
 			bind:checked={$returnYtDislikesStore}
 			onclick={() => returnYtDislikesStore.set(!$returnYtDislikesStore)}
 			type="checkbox"
+			role="switch"
 		/>
 		<span></span>
 	</label>

--- a/materialious/src/lib/components/Settings/SponsorBlock.svelte
+++ b/materialious/src/lib/components/Settings/SponsorBlock.svelte
@@ -61,11 +61,12 @@
 	<div class="max">
 		<p>{$_('enabled')}</p>
 	</div>
-	<label class="switch" tabindex="0" role="switch">
+	<label class="switch" tabindex="0">
 		<input
 			bind:checked={$sponsorBlockStore}
 			onclick={() => sponsorBlockStore.set(!$sponsorBlockStore)}
 			type="checkbox"
+			role="switch"
 		/>
 		<span></span>
 	</label>
@@ -75,11 +76,12 @@
 	<div class="max">
 		<p>{$_('layout.sponsors.disableToast')}</p>
 	</div>
-	<label class="switch" tabindex="0" role="switch">
+	<label class="switch" tabindex="0">
 		<input
 			bind:checked={$sponsorBlockDisplayToastStore}
 			onclick={() => sponsorBlockDisplayToastStore.set(!$sponsorBlockDisplayToastStore)}
 			type="checkbox"
+			role="switch"
 		/>
 		<span></span>
 	</label>
@@ -109,11 +111,12 @@
 			<div class="max">
 				<p>{sponsor.name}</p>
 			</div>
-			<label class="switch" tabindex="0" role="switch">
+			<label class="switch" tabindex="0">
 				<input
 					type="checkbox"
 					checked={sponsorCategoriesList.includes(sponsor.category)}
 					onclick={() => toggleSponsor(sponsor.category)}
+					role="switch"
 				/>
 				<span></span>
 			</label>


### PR DESCRIPTION
We had a lot of a11y warnings on build. We still have some now, but not that many any more. The settings tabs are now navigable by keyboard and should be announced correctly. The solution is not perfect (yet), as BeerCSS requires some things to be done that way, unfortunately.

Solves parts of #1021 