### PR TITLE
Thumbnail: Fix use of viewCount (Invidious API change)

### DIFF
--- a/materialious/src/lib/components/Thumbnail.svelte
+++ b/materialious/src/lib/components/Thumbnail.svelte
@@ -226,7 +226,9 @@
 
 				{#if 'publishedText' in video}
 					<div class="max">
-						{cleanNumber(video.viewCount)} • {video.publishedText}
+						{('viewCount' in video) ? cleanNumber(video.viewCount) : (video.viewCountText || "")}
+						•
+						{video.publishedText}
 					</div>
 				{/if}
 			</div>


### PR DESCRIPTION
Invidious removed viewCount from the API for related/recommended videos. Thus, opening a video causes a JS exception and the page doesn't render.
See https://github.com/iv-org/invidious/pull/5446

Use viewCountText if viewCount is missing. I'm not sure if this code path is only used with that API endpoint, so I have kept a check for viewCount.