### PR TITLE
Fix thumbnail rendering for certain iOS devices

### DIFF
--- a/materialious/src/lib/components/Thumbnail.svelte
+++ b/materialious/src/lib/components/Thumbnail.svelte
@@ -253,6 +253,7 @@
 	.thumbnail {
 		width: 100%;
 		overflow: hidden;
+		display: inline-block;
 	}
 
 	.thumbnail img {


### PR DESCRIPTION
On certain iOS devices the thumbnail does not render. It seems to be a glitch in the flex box implementation of webkit. This PR fixes the thumbnail not rendering. All other layout / positioning is not changed.