### PR TITLE
Make progress bar move smoother

### DIFF
--- a/materialious/src/lib/components/Player.svelte
+++ b/materialious/src/lib/components/Player.svelte
@@ -974,7 +974,7 @@
 	{#if !hideControls}
 		<div id="player-controls">
 			<article class="round" style="width: 100%;padding: 0;height: 10px;">
-				<label class="slider max">
+				<label id="progress-slider" class="slider max">
 					{#key playerCurrentTime}
 						<input
 							oninput={handleTimeChange}
@@ -1295,6 +1295,10 @@
 		border: none;
 		opacity: 0;
 		transition: opacity 2s ease;
+	}
+
+	#progress-slider > span {
+		transition: 0.25s;
 	}
 
 	#player-container:focus-within #player-controls,


### PR DESCRIPTION
Add a transition to the progress slider to make it move smoother in
between slider steps while playing the video. The steps were especially
noticeable when playing shorter videos.
