### PR TITLE
Fix API path for channel search endpoint

### DIFF
--- a/materialious/src/lib/api/invidious/channel.ts
+++ b/materialious/src/lib/api/invidious/channel.ts
@@ -39,7 +39,7 @@ export async function searchChannelContentInvidious(
 	search: string,
 	fetchOptions?: RequestInit
 ): Promise<ChannelContent> {
-	const path = buildPath(`channel/${channelId}/search`);
+	const path = buildPath(`channels/${channelId}/search`);
 	path.searchParams.set('q', search);
 
 	const resp = await fetchErrorHandle(await fetch(path, fetchOptions));


### PR DESCRIPTION
Ref: https://docs.invidious.io/api/channels_endpoint/#get-apiv1channelsucidsearch

