### PR TITLE
fix: handle ISO string timestamps in related video thumbnails

### DIFF
--- a/materialious/src/lib/components/thumbnail/VideoThumbnail.svelte
+++ b/materialious/src/lib/components/thumbnail/VideoThumbnail.svelte
@@ -359,7 +359,12 @@
 									{video.viewCountText ?? cleanNumber(video.viewCount ?? 0)}
 									•
 									{video.published && video.published !== 0
-										? relativeTimestamp(video.published * 1000, false)
+										? relativeTimestamp(
+												typeof video.published === 'string'
+													? new Date(video.published).getTime()
+													: video.published * 1000,
+												false
+											)
 										: video.publishedText}
 								</span>
 							{/if}


### PR DESCRIPTION
Fixes #1577

Related videos from some Invidious backends return `published` as an ISO 8601 string (e.g. `"2026-02-15T18:38:17Z"`) instead of a Unix epoch number. Multiplying a string by 1000 produces NaN, which dayjs renders as "Invalid Date".

Added a typeof check — if it's a string, parse it with `Date` first.

Cheers,
saschabuehrle