### PR TITLE
refactor: add `isshort` property to video and thumbnailvideo models

### DIFF
--- a/materialious/src/lib/api/model.ts
+++ b/materialious/src/lib/api/model.ts
@@ -34,6 +34,7 @@ export interface VideoBase {
 	// Means it was given preference in rankings due to
 	// a users settings
 	promotedBy?: 'favourited';
+	isShort?: boolean;
 }
 
 export interface ResolvedUrl {


### PR DESCRIPTION
### Problem

The `Video` and `ThumbnailVideo` interfaces need an `isShort` boolean property to indicate if a video is a YouTube Short. This property will be used downstream for conditional rendering of thumbnails.

### Changes

The `Video` and `ThumbnailVideo` interfaces need an `isShort` boolean property to indicate if a video is a YouTube Short. This property will be used downstream for conditional rendering of thumbnails.

**Modified files:**
- `materialious/src/lib/api/model.ts` (modified)

---
Tested by running the project's existing test suite. No unrelated changes included.


Closes #670