### PR TITLE
Fix Android DASH playback with Invidious proxying and no local fallback

### DIFF
--- a/materialious/src/lib/player/manifest.ts
+++ b/materialious/src/lib/player/manifest.ts
@@ -1,29 +1,16 @@
 export async function manifestDomainInclusion(manifestUrl: string): Promise<string> {
-	const respIvg = await fetch(manifestUrl, {
+	const resp = await fetch(manifestUrl, {
 		method: 'GET',
-		headers: {
-			// Required for our custom android backend.
-			__redirect: 'manual'
-		},
 		referrerPolicy: 'no-referrer'
 	});
 
-	if (!respIvg.ok) {
+	if (!resp.ok) {
 		throw Error('Unable to make request to Invidious');
 	}
 
-	// If location isn't present, then use base manifest URL.
-	const companionUrl = respIvg.headers.get('location') ?? manifestUrl;
-
-	const respCompanion = await fetch(companionUrl, {
-		method: 'GET'
-	});
-
-	if (!respCompanion.ok) {
-		throw Error('Unable to make request to Companion');
-	}
-
-	const manifestText = await respCompanion.text();
+	// Used to resolve relative BaseURL entries in the manifest.
+	const companionUrl = resp.headers.get('x-final-url') ?? manifestUrl;
+	const manifestText = await resp.text();
 
 	const parser = new DOMParser();
 	const xmlDoc = parser.parseFromString(manifestText, 'application/xml');
@@ -35,10 +22,7 @@ export async function manifestDomainInclusion(manifestUrl: string): Promise<stri
 		const baseUrlValue = baseUrlElement.textContent;
 
 		if (baseUrlValue && (baseUrlValue.startsWith('/') || !baseUrlValue.includes('://'))) {
-			const companionUrlObj = new URL(companionUrl);
-			const baseDomain = `${companionUrlObj.protocol}//${companionUrlObj.host}`;
-			const resolvedUrl = new URL(baseUrlValue, baseDomain).href;
-			baseUrlElement.textContent = resolvedUrl;
+			baseUrlElement.textContent = new URL(baseUrlValue, companionUrl).href;
 		}
 	}
 

--- a/materialious/src/routes/(app)/+layout.svelte
+++ b/materialious/src/routes/(app)/+layout.svelte
@@ -96,7 +96,6 @@
 			method: 'POST',
 			body: body,
 			headers: {
-				__redirect: 'manual',
 				__custom_return: 'json-headers'
 			}
 		});

--- a/materialious/src/routes/api/proxy/[urlToProxy]/+server.ts
+++ b/materialious/src/routes/api/proxy/[urlToProxy]/+server.ts
@@ -159,6 +159,7 @@ async function proxyRequest(
 	const responseHeaders = new Headers(response.headers);
 	responseHeaders.delete('content-encoding');
 	responseHeaders.delete('content-length');
+	responseHeaders.set('x-final-url', response.url);
 
 	return new Response(response.body, {
 		status: response.status,

--- a/materialious/static/nodejsAndroid/index.js
+++ b/materialious/static/nodejsAndroid/index.js
@@ -27,7 +27,6 @@ const CORS_HEADERS = [
 	'Range',
 	'Referer',
 	'Cookie',
-	'__redirect',
 	'__custom_return',
 	'__sid_auth'
 ].join(', ');
@@ -40,6 +39,7 @@ function setCorsHeaders(res) {
 	res.setHeader('Access-Control-Allow-Origin', CORS_ORIGIN);
 	res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
 	res.setHeader('Access-Control-Allow-Headers', CORS_HEADERS);
+	res.setHeader('Access-Control-Expose-Headers', 'x-final-url');
 	res.setHeader('Access-Control-Max-Age', '86400');
 	res.setHeader('Access-Control-Allow-Credentials', 'true');
 }
@@ -50,8 +50,6 @@ function proxyRequest(clientReq, clientRes, parsedUrl, bodyChunks = [], redirect
 		return clientRes.end('Too many redirects');
 	}
 
-	const redirectAllowed = clientReq.headers.__redirect !== 'manual';
-	delete clientReq.headers.__redirect;
 	const returnHeadersAsJson = clientReq.headers.__custom_return === 'json-headers';
 	delete clientReq.headers.__custom_return;
 
@@ -88,19 +86,14 @@ function proxyRequest(clientReq, clientRes, parsedUrl, bodyChunks = [], redirect
 	}
 
 	const proxyReq = httpClient.request(parsedUrl, proxyOptions, (proxyRes) => {
-		// Handle redirects normally if redirectAllowed
-		if (
+		const isRedirect =
 			proxyRes.statusCode >= 300 &&
 			proxyRes.statusCode < 400 &&
-			proxyRes.headers.location &&
-			redirectAllowed
-		) {
-			proxyRes.resume(); // discard response data
-			const newUrl = new URL(proxyRes.headers.location, parsedUrl);
-			return proxyRequest(clientReq, clientRes, newUrl, bodyChunks, redirectCount + 1);
-		}
+			proxyRes.headers.location;
 
 		if (returnHeadersAsJson) {
+			// Used by the TV login flow to read upstream response headers as JSON.
+			proxyRes.resume();
 			const headersDict = {};
 			for (const [key, value] of Object.entries(proxyRes.headers)) {
 				headersDict[key] = value;
@@ -110,13 +103,15 @@ function proxyRequest(clientReq, clientRes, parsedUrl, bodyChunks = [], redirect
 
 			clientRes.writeHead(200, {
 				'Content-Type': 'application/json',
-				'Access-Control-Allow-Origin': CORS_ORIGIN,
-				'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
-				'Access-Control-Allow-Headers': CORS_HEADERS,
-				'Access-Control-Allow-Credentials': 'true',
 				'Content-Length': Buffer.byteLength(body)
 			});
 			return clientRes.end(body);
+		}
+
+		if (isRedirect) {
+			proxyRes.resume();
+			const newUrl = new URL(proxyRes.headers.location, parsedUrl);
+			return proxyRequest(clientReq, clientRes, newUrl, bodyChunks, redirectCount + 1);
 		}
 
 		clientRes.writeHead(proxyRes.statusCode, {
@@ -124,9 +119,10 @@ function proxyRequest(clientReq, clientRes, parsedUrl, bodyChunks = [], redirect
 			'Access-Control-Allow-Origin': CORS_ORIGIN,
 			'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
 			'Access-Control-Allow-Headers': CORS_HEADERS,
-			'Access-Control-Allow-Credentials': 'true'
+			'Access-Control-Expose-Headers': 'x-final-url',
+			'Access-Control-Allow-Credentials': 'true',
+			'x-final-url': parsedUrl.href
 		});
-
 		proxyRes.pipe(clientRes);
 	});
 


### PR DESCRIPTION
## Summary

Fixes Android playback when local fallback is disabled and DASH manifests are proxied through an Invidious instance that redirects manifest requests to Companion.

Previously, the Android localhost proxy could expose the upstream redirect to the WebView. The WebView then followed the redirect directly to Companion using origin `https://www.youtube.com`, and Companion rejected the request on CORS. This made playback fail entirely in the Invidious-proxied, no-local-fallback setup.

Fixes #1644.

## Changes

- Follow Android proxy redirects server-side instead of exposing them to the WebView.
- Add `x-final-url` to final Android proxy responses.
- Expose `x-final-url` through Android proxy CORS headers.
- Use `x-final-url` when rewriting DASH manifests so relative `BaseURL` entries resolve against the final manifest URL.
- Add `x-final-url` to the SvelteKit proxy path for consistency.
- Remove the unused `__redirect: manual` TV login header while preserving `__custom_return: json-headers`.

## Validation

- `npm run check`
- `npm run eslint`

## AI Assistance Disclosure

This change was prepared with Claude Code using Claude Opus 4.7 and reviewed with Codex using GPT-5.5. The implementation was manually reviewed, and the validation commands above were run locally.

## Notes

Android TV login remains intentionally special-cased: `__custom_return: json-headers` is handled before redirect-following so the login flow can still read upstream response headers such as `set-cookie`.
