### PR TITLE
Fix title case instead of original casing being used

### DIFF
--- a/materialious/src/lib/letterCasing.ts
+++ b/materialious/src/lib/letterCasing.ts
@@ -27,8 +27,11 @@ export function letterCase(text: string, caseTypeOverwrite?: TitleCase): string 
 			return text.toUpperCase();
 		case 'sentence case':
 			return sentenceCase(text);
-		default:
+		case 'title case':
 			return titleCase(text);
+		case 'original':
+		default:
+			return text;
 	}
 }
 


### PR DESCRIPTION
The letterCase function was still applying title case even when the forceCase setting was set to original. Setting it to original thus had no effect.