### PR TITLE
Fix typo in en.json

### DIFF
--- a/materialious/src/lib/i18n/locales/en.json
+++ b/materialious/src/lib/i18n/locales/en.json
@@ -250,7 +250,7 @@
 		"passwordResetSuccess": "Password reset successfully",
 		"changePassword": "Change password",
 		"historyEnabled": "Save watch history",
-		"preserveTranslation": "Use original traslation",
+		"preserveTranslation": "Use original translation",
 		"showMobileBackButton": "On screen navigation controls",
 		"theme": {
 			"theme": "Theme",


### PR DESCRIPTION
I found a typo in the English translation (en.json):

_traslation -> translation_