### PR TITLE
Fix localDb calls (Dexie)

### DIFF
--- a/materialious/src/lib/api/index.ts
+++ b/materialious/src/lib/api/index.ts
@@ -333,7 +333,7 @@ export async function getVideoWatchHistory(
 		return getVideoWatchHistoryBackend(videoId);
 	}
 
-	return await localDb.watchHistory.get({ videoId });
+	return await localDb.watchHistory.get(videoId);
 }
 
 export async function deleteWatchHistory() {
@@ -349,7 +349,7 @@ export async function deleteWatchHistoryItem(videoId: string) {
 		return deleteWatchHistoryItemBackend(videoId);
 	}
 
-	await localDb.watchHistory.delete({ videoId });
+	await localDb.watchHistory.delete(videoId);
 }
 
 export async function updateWatchHistory(
@@ -365,7 +365,7 @@ export async function updateWatchHistory(
 
 	if (get(invidiousAuthStore)) postHistoryInvidious(videoId, fetchOptions);
 
-	await localDb.watchHistory.update({ videoId }, { progress, watched: new Date() });
+	await localDb.watchHistory.update(videoId, { progress, watched: new Date() });
 }
 
 export async function saveWatchHistory(video: ThumbnailVideo, progress: number = 0) {
@@ -375,7 +375,7 @@ export async function saveWatchHistory(video: ThumbnailVideo, progress: number =
 		return saveWatchHistoryBackend(video, progress);
 	}
 
-	if (await localDb.watchHistory.get({ videoId: video.videoId })) return;
+	if (await localDb.watchHistory.get(video.videoId)) return;
 
 	await localDb.watchHistory.add({
 		author: video.author,

--- a/materialious/src/lib/thumbnail.ts
+++ b/materialious/src/lib/thumbnail.ts
@@ -27,7 +27,7 @@ export async function associateAvatar(channelId: string, avatars: Image[]) {
 			avatarUrl: getBestThumbnail(avatars),
 			updated: new Date()
 		},
-		{ channelId: channelId }
+		channelId
 	);
 
 	if (isInitial) {
@@ -40,7 +40,7 @@ export async function associateAvatar(channelId: string, avatars: Image[]) {
 }
 
 export async function avatarFromChannelId(channelId: string): Promise<void | string> {
-	const result = await localDb.channelAvatars.get({ channelId });
+	const result = await localDb.channelAvatars.get(channelId);
 	if (result) {
 		return result.avatarUrl;
 	}


### PR DESCRIPTION
## Motivation

Watch history toggle is not working as of now. Videos can't be marked as "unwatched" from the thumbnail UI.

Closes #1812.

## Root Cause

The code uses incorrect Dexie API patterns for tables with simple primary keys. The `watchHistory` and `channelAvatars` tables are defined with simple PKs (`videoId`, `channelId`), but the code was passing objects like `{ videoId }` instead of raw key values.

Dexie's `.get()` accepts both forms, but when given an object it falls back to `.where().first()` — treating the input as filter criteria rather than a direct PK lookup. This is less efficient and fragile. Meanwhile, `.delete()` and `.update()` pass the value directly to IndexedDB's native `IDBObjectStore.delete()`, which strictly requires a raw key and throws a `DataError` when given an object.

```ts
// ✅ Correct — direct PK lookup, O(1)
db.watchHistory.get(videoId)

// ⚠️ Falls back to .where().first() — filter-based, less efficient
db.watchHistory.get({ videoId })
```

## Fixes

**`src/lib/api/index.ts`** — 4 calls fixed:
- `getVideoWatchHistory`: `.get({ videoId })` → `.get(videoId)`
- `deleteWatchHistoryItem`: `.delete({ videoId })` → `.delete(videoId)`
- `updateWatchHistory`: `.update({ videoId }, ...)` → `.update(videoId, ...)`
- `saveWatchHistory`: `.get({ videoId: video.videoId })` → `.get(video.videoId)`

**`src/lib/thumbnail.ts`** — 2 calls fixed:
- `avatarFromChannelId`: `.get({ channelId })` → `.get(channelId)`
- `associateAvatar`: `.put(..., { channelId: channelId })` → `.put(..., channelId)`


Disclosure: investigation and fixes were assisted by local AI agent (zed) using a local model, reviewed and manually tested in a local dev build by myself.