### PR TITLE
fix: remove Android fullscreen listener on every video, not just TV

### DIFF
--- a/materialious/src/lib/components/player/Player.svelte
+++ b/materialious/src/lib/components/player/Player.svelte
@@ -790,9 +790,7 @@
 			await setStatusBarColor();
 			await CapacitorMusicControls.destroy();
 
-			if ($isAndroidTvStore) {
-				document.removeEventListener('fullscreenchange', onAndroidFullscreenChange);
-			}
+			document.removeEventListener('fullscreenchange', onAndroidFullscreenChange);
 
 			if (androidOriginalOrigination) {
 				await ScreenOrientation.lock({


### PR DESCRIPTION
## Summary

Fixes #1656 (and duplicates #1798, #1175, #1112, #671, #639, #1211) — auto-rotate to landscape on fullscreen only works for the first video watched in a session; subsequent videos need an app restart to rotate correctly.

## Root cause

`androidHandleRotate()` adds a `document`-level `fullscreenchange` listener whenever the platform is Android **and not** Android TV:

```js
async function androidHandleRotate() {
	if (
		Capacitor.getPlatform() !== 'android' ||
		data.video.adaptiveFormats.length === 0 ||
		$isAndroidTvStore
	)
		return;
	...
	document.addEventListener('fullscreenchange', onAndroidFullscreenChange);
}
```

But `onDestroy` only ever removed it when `$isAndroidTvStore` **is** true:

```js
if ($isAndroidTvStore) {
	document.removeEventListener('fullscreenchange', onAndroidFullscreenChange);
}
```

This condition is inverted relative to where the listener is added, so on regular phones/tablets the listener is never cleaned up. Each video watched in a session leaves its own listener attached to `document`; on the second video there are now two listeners racing each other's `ScreenOrientation.lock()` calls on fullscreen toggle (three on the third video, etc.), which is why rotation becomes unreliable after the first video and a full app restart is the only thing that clears it (killing the process is what resets `document`'s listener list).

This looks like an unintentional regression from inlining the former standalone `android.ts` player class (which removed this listener unconditionally) directly into `Player.svelte` in 6f68854 — the original class had no TV gating on removal at all.

## Fix

Remove the `$isAndroidTvStore` gate on the listener removal so it's always cleaned up on Android (matching the add condition's scope). `removeEventListener` is a no-op if the listener was never added, so this is safe for the TV path too.

## Test plan

- [x] `npm run lint` — 0 new issues (pre-existing prettier/eslint warnings in unrelated files only)
- [x] `npm run check` — 0 errors (pre-existing warnings in unrelated files only)
- [x] `npm run build` — builds successfully
- [ ] Manual verification on a physical Android device (I don't have a build pipeline for a signed APK handy — would appreciate a maintainer or the reporters on #1656 confirming on-device)