### PR TITLE
Fix download filenames and incompatible merges

### DIFF
--- a/materialious/shared/src/download/ffmpeg.ts
+++ b/materialious/shared/src/download/ffmpeg.ts
@@ -56,11 +56,14 @@ export function inferMergeContainer(
 		return 'mp4';
 	}
 
-	if (
+	const webmVideo =
 		videoCodec.startsWith('vp9') ||
+		videoCodec.startsWith('vp09') ||
 		videoCodec.startsWith('vp8') ||
-		videoCodec.startsWith('av01')
-	) {
+		videoCodec.startsWith('av01');
+	const webmAudio = audioCodec.startsWith('opus') || audioCodec.startsWith('vorbis');
+
+	if (webmVideo && webmAudio) {
 		return 'webm';
 	}
 

--- a/materialious/src/lib/api/youtubejs/download.ts
+++ b/materialious/src/lib/api/youtubejs/download.ts
@@ -52,6 +52,15 @@ export async function startElectronDownload(
 }
 
 function filenameFromDisposition(disposition: string): string | undefined {
+	const encoded = /filename\*\s*=\s*UTF-8''([^;]+)/i.exec(disposition)?.[1];
+	if (encoded !== undefined) {
+		try {
+			return decodeURIComponent(encoded);
+		} catch {
+			// Fall through to the legacy filename parameter below.
+		}
+	}
+
 	const quoted = /filename="([^"]*)"/i.exec(disposition)?.[1];
 	if (quoted !== undefined) return quoted;
 	return /filename=([^;]+)/i.exec(disposition)?.[1]?.trim();

--- a/materialious/src/routes/api/download/+server.ts
+++ b/materialious/src/routes/api/download/+server.ts
@@ -14,6 +14,14 @@ const zDownloadSchema = z.object({
 	codec: z.string().optional()
 });
 
+function contentDisposition(filename: string): string {
+	// `filename` is an ASCII fallback for older clients. `filename*` preserves
+	// the original Unicode title without putting non-ByteString characters in a
+	// Node response header.
+	const fallback = filename.replace(/[^\x20-\x7e]/g, '_').replace(/[;"\\]/g, '_');
+	return `attachment; filename="${fallback}"; filename*=UTF-8''${encodeURIComponent(filename)}`;
+}
+
 export async function GET({ request, url, locals }) {
 	if (isOwnBackend()?.requireAuth && !locals.userId) {
 		throw error(401);
@@ -49,7 +57,7 @@ export async function GET({ request, url, locals }) {
 
 	const headers = new Headers({
 		'Content-Type': resolved.mimeType,
-		'Content-Disposition': `attachment; filename="${resolved.filename}"`,
+		'Content-Disposition': contentDisposition(resolved.filename),
 		'Cache-Control': 'no-store'
 	});
 


### PR DESCRIPTION
This fixes two issues in the web download flow that showed up together in real downloads.

Download responses now send a safe ASCII filename fallback alongside RFC 5987 filename*. The fallback keeps ordinary spaces, while the client reads filename* first so titles with Unicode characters are preserved instead of ending up as download.txt.

The merge container is now chosen from both selected codecs. A VP9 or AV1 video stream paired with AAC is written as Matroska rather than WebM, which avoids ffmpeg producing a tiny header-only file. Compatible VP9/Opus and H.264/AAC pairs still use WebM and MP4 respectively.

I verified the response headers and ran a 1440p merged download end to end. It produced a 62 MB Matroska file with the expected container signature rather than the previous 251-byte output.